### PR TITLE
Flag support (#24)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,9 +4,9 @@ Thanks for taking precious time for making a PR.
 Before creating a pull request, please make sure:
 - Your PR solves one problem for which a issue exist and a solution has been discussed
 - You have read the guide for contributing
-  - See https://github.com/beatlabs/harvester/blob/master/CONTRIBUTING.md
+  - See https://github.com/beatlabs/harvester/blob/master/CONTRIBUTE.md
 - You signed all your commits (otherwise we won't be able to merge the PR)
-  - See https://github.com/beatlabs/harvester/blob/master/CONTRIBUTING.md#sign-your-work
+  - See https://github.com/beatlabs/harvester/blob/master/SIGNYOURWORK.md
 - You added unit tests for the new functionality
 - You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
 -->

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The order is applied as it is listed above. Consul seeder and monitor are option
 type Config struct {
     Name    sync.String  `seed:"John Doe"`
     Age     sync.Int64   `seed:"18" env:"ENV_AGE"`
-	City    sync.String  `seed:"London" flag:"city"`
+    City    sync.String  `seed:"London" flag:"city"`
     IsAdmin sync.Bool    `seed:"true" env:"ENV_IS_ADMIN" consul:"/config/is-admin"`
 }
 ```

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Configuration can be obtained from the following sources:
 
 - Seed values, are hard-coded values into your configuration struct
 - Environment values, are obtained from the environment
+- Flag values, are obtained from CLI flags with the form `-flag=value`
 - Consul, which is used to get initial values and to monitor them for changes
 
 The order is applied as it is listed above. Consul seeder and monitor are optional and will be used only if `Harvester` is created with the above components.
@@ -17,6 +18,7 @@ The order is applied as it is listed above. Consul seeder and monitor are option
 type Config struct {
     Name    sync.String  `seed:"John Doe"`
     Age     sync.Int64   `seed:"18" env:"ENV_AGE"`
+	City    sync.String  `seed:"London" flag:"city"`
     IsAdmin sync.Bool    `seed:"true" env:"ENV_IS_ADMIN" consul:"/config/is-admin"`
 }
 ```
@@ -25,6 +27,7 @@ The above defines the following fields:
 
 - Name, which will be seeded with the value `John Doe`
 - Age, which will be seeded with the value `18`, and if exists, overridden with whatever value the env var `ENV_AGE` holds
+- City, which will be seeded with the value `London`, and if exists, overridden with whatever value the flag `city` holds
 - IsAdmin, which will be seeded with the value `true`, and if exists, overridden with whatever value the env var `ENV_AGE` holds and then from consul if the consul seeder and/or watcher are provided.
 
 The fields have to be one of the types that the sync package supports in order to allow concurrent read and write to the fields. The following types are supported:
@@ -41,6 +44,7 @@ The fields have to be one of the types that the sync package supports in order t
 - Apply the seed tag value, if present
 - Apply the value contained in the env var, if present
 - Apply the value returned from Consul, if present and harvester is setup to seed from consul
+- Apply the value contained in the CLI flags, if present
 
 Conditions where seeding fails:
 

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,8 @@ const (
 	SourceEnv Source = "env"
 	// SourceConsul defines a value from consul.
 	SourceConsul Source = "consul"
+	// SourceFlag defines a value from CLI flag.
+	SourceFlag Source = "flag"
 )
 
 // Field definition of a config value that can change.
@@ -53,6 +55,10 @@ func NewField(fld *reflect.StructField, val *reflect.Value) (*Field, error) {
 	value, ok = fld.Tag.Lookup(string(SourceConsul))
 	if ok {
 		f.sources[SourceConsul] = value
+	}
+	value, ok = fld.Tag.Lookup(string(SourceFlag))
+	if ok {
+		f.sources[SourceFlag] = value
 	}
 	return f, nil
 }

--- a/examples/01_basic/main.go
+++ b/examples/01_basic/main.go
@@ -12,6 +12,7 @@ import (
 type config struct {
 	Name sync.String `seed:"John Doe"`
 	Age  sync.Int64  `seed:"18" env:"ENV_AGE"`
+	City sync.String  `seed:"London" flag:"city"`
 }
 
 func main() {
@@ -35,5 +36,5 @@ func main() {
 		log.Fatalf("failed to harvest configuration: %v", err)
 	}
 
-	log.Printf("Config : Name: %s, Age: %d\n", cfg.Name.Get(), cfg.Age.Get())
+	log.Printf("Config : Name: %s, Age: %d, City: %s\n", cfg.Name.Get(), cfg.Age.Get(), cfg.City.Get())
 }

--- a/examples/01_basic/main.go
+++ b/examples/01_basic/main.go
@@ -12,7 +12,7 @@ import (
 type config struct {
 	Name sync.String `seed:"John Doe"`
 	Age  sync.Int64  `seed:"18" env:"ENV_AGE"`
-	City sync.String  `seed:"London" flag:"city"`
+	City sync.String `seed:"London" flag:"city"`
 }
 
 func main() {

--- a/examples/02_consul/main.go
+++ b/examples/02_consul/main.go
@@ -13,6 +13,7 @@ import (
 type config struct {
 	Name    sync.String  `seed:"John Doe"`
 	Age     sync.Int64   `seed:"18" env:"ENV_AGE"`
+	City    sync.String  `seed:"London" flag:"city"`
 	Balance sync.Float64 `seed:"99.9" env:"ENV_CONSUL_VAR" consul:"harvester/example_02/balance"`
 }
 
@@ -41,7 +42,7 @@ func main() {
 		log.Fatalf("failed to harvest configuration: %v", err)
 	}
 
-	log.Printf("Config: Name: %s, Age: %d, Balance: %f\n", cfg.Name.Get(), cfg.Age.Get(), cfg.Balance.Get())
+	log.Printf("Config: Name: %s, Age: %d, City: %s, Balance: %f\n", cfg.Name.Get(), cfg.Age.Get(), cfg.City.Get(), cfg.Balance.Get())
 }
 
 func seedConsulVars() {

--- a/examples/03_consul_monitor/main.go
+++ b/examples/03_consul_monitor/main.go
@@ -15,6 +15,7 @@ import (
 type config struct {
 	Name    sync.String  `seed:"John Doe"`
 	Age     sync.Int64   `seed:"18" env:"ENV_AGE"`
+	City    sync.String  `seed:"London" flag:"city"`
 	Balance sync.Float64 `seed:"99.9" consul:"harvester/example_03/balance"`
 }
 
@@ -46,13 +47,13 @@ func main() {
 		log.Fatalf("failed to harvest configuration: %v", err)
 	}
 
-	log.Printf("Config: Name: %s, Age: %d, Balance: %f\n", cfg.Name.Get(), cfg.Age.Get(), cfg.Balance.Get())
+	log.Printf("Config: Name: %s, Age: %d, City: %s, Balance: %f\n", cfg.Name.Get(), cfg.Age.Get(), cfg.City.Get(), cfg.Balance.Get())
 
 	time.Sleep(time.Second)
 	seedConsulBalance("999.99")
 
 	time.Sleep(time.Second)
-	log.Printf("Config: Name: %s, Age: %d, Balance: %f\n", cfg.Name.Get(), cfg.Age.Get(), cfg.Balance.Get())
+	log.Printf("Config: Name: %s, Age: %d, City: %s, Balance: %f\n", cfg.Name.Get(), cfg.Age.Get(), cfg.City.Get(), cfg.Balance.Get())
 }
 
 func seedConsulBalance(balance string) {

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,23 +22,41 @@ A fast way to get consul is the following:
 
     go run examples/02_consul/main.go
 
-    2019/06/04 22:05:04 INFO: seed value John Doe applied on Name
-    2019/06/04 22:05:04 INFO: seed value 18 applied on Age
-    2019/06/04 22:05:04 WARN: env var ENV_AGE did not exist for Age
-    2019/06/04 22:05:04 INFO: seed value 99.9 applied on Balance
-    2019/06/04 22:05:04 WARN: env var ENV_CONSUL_VAR did not exist for Balance
-    2019/06/04 22:05:04 INFO: consul value 123.45 applied on Balance
-    2019/06/04 22:05:04 Config: Name: John Doe, Age: 18, Balance: 123.450000
+    2019/07/12 14:40:04 INFO: field Name updated with value John Doe, version: 0
+    2019/07/12 14:40:04 INFO: seed value John Doe applied on field Name
+    2019/07/12 14:40:04 INFO: field Age updated with value 18, version: 0
+    2019/07/12 14:40:04 INFO: seed value 18 applied on field Age
+    2019/07/12 14:40:04 INFO: field Age updated with value 25, version: 0
+    2019/07/12 14:40:04 INFO: env var value 25 applied on field Age
+    2019/07/12 14:40:04 INFO: field City updated with value London, version: 0
+    2019/07/12 14:40:04 INFO: seed value London applied on field City
+    2019/07/12 14:40:04 INFO: field Balance updated with value 99.9, version: 0
+    2019/07/12 14:40:04 INFO: seed value 99.9 applied on field Balance
+    2019/07/12 14:40:04 WARN: env var ENV_CONSUL_VAR did not exist for field Balance
+    2019/07/12 14:40:04 INFO: field Balance updated with value 123.45, version: 7642
+    2019/07/12 14:40:04 INFO: consul value 123.45 applied on field Balance
+    2019/07/12 14:40:04 WARN: flag var city did not exist for field City
+    2019/07/12 14:40:04 Config: Name: John Doe, Age: 25, City: London, Balance: 123.450000
 
 ## 03 Monitor Consul for live changes
 
     go run examples/03_consul_monitor/main.go
 
-    2019/06/04 22:05:32 INFO: seed value John Doe applied on Name
-    2019/06/04 22:05:32 INFO: seed value 18 applied on Age
-    2019/06/04 22:05:32 WARN: env var ENV_AGE did not exist for Age
-    2019/06/04 22:05:32 INFO: seed value 99.9 applied on Balance
-    2019/06/04 22:05:32 WARN: env var ENV_CONSUL_VAR did not exist for Balance
-    2019/06/04 22:05:32 INFO: consul value 123.45 applied on Balance
-    2019/06/04 22:05:32 Config: Name: John Doe, Age: 18, Balance: 123.450000
-    2019/06/04 22:05:34 Config: Name: John Doe, Age: 18, Balance: 999.990000
+    2019/07/12 14:41:30 INFO: field Name updated with value John Doe, version: 0
+    2019/07/12 14:41:30 INFO: seed value John Doe applied on field Name
+    2019/07/12 14:41:30 INFO: field Age updated with value 18, version: 0
+    2019/07/12 14:41:30 INFO: seed value 18 applied on field Age
+    2019/07/12 14:41:30 INFO: field Age updated with value 25, version: 0
+    2019/07/12 14:41:30 INFO: env var value 25 applied on field Age
+    2019/07/12 14:41:30 INFO: field City updated with value London, version: 0
+    2019/07/12 14:41:30 INFO: seed value London applied on field City
+    2019/07/12 14:41:30 INFO: field Balance updated with value 99.9, version: 0
+    2019/07/12 14:41:30 INFO: seed value 99.9 applied on field Balance
+    2019/07/12 14:41:30 INFO: field Balance updated with value 123.45, version: 7647
+    2019/07/12 14:41:30 INFO: consul value 123.45 applied on field Balance
+    2019/07/12 14:41:30 WARN: flag var city did not exist for field City
+    2019/07/12 14:41:30 INFO: plan for key harvester/example_03/balance created
+    2019/07/12 14:41:30 Config: Name: John Doe, Age: 25, City: London, Balance: 123.450000
+    2019/07/12 14:41:30 WARN: version 7647 is older or same as the field's Balance
+    2019/07/12 14:41:31 INFO: field Balance updated with value 999.99, version: 7649
+    2019/07/12 14:41:32 Config: Name: John Doe, Age: 25, City: London, Balance: 999.990000

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -81,6 +81,12 @@ func (s *Seeder) Seed(cfg *config.Config) error {
 				log.Warnf("env var %s did not exist for field %s", key, f.Name())
 			}
 		}
+		key, ok = ss[config.SourceFlag]
+		if ok {
+			var val string
+			flagset.StringVar(&val, key, "", "")
+			flagInfos = append(flagInfos, &flagInfo{key, f, &val})
+		}
 		key, ok = ss[config.SourceConsul]
 		if ok {
 			gtr, ok := s.getters[config.SourceConsul]
@@ -102,12 +108,6 @@ func (s *Seeder) Seed(cfg *config.Config) error {
 			}
 			log.Infof("consul value %s applied on field %s", *value, f.Name())
 			seedMap[f] = true
-		}
-		key, ok = ss[config.SourceFlag]
-		if ok {
-			var val string
-			flagset.StringVar(&val, key, "", "")
-			flagInfos = append(flagInfos, &flagInfo{key, f, &val})
 		}
 	}
 

--- a/seed/seed_test.go
+++ b/seed/seed_test.go
@@ -39,32 +39,25 @@ func TestNewParam(t *testing.T) {
 }
 
 type flagConfig interface {
-	GetAge() sync.Int64
+	GetAge() *sync.Int64
 }
 
 type configWithSeedStruct struct {
 	Age sync.Int64 `seed:"42" flag:"age"`
 }
 
-func (c configWithSeedStruct) GetAge() sync.Int64 { return c.Age }
+func (c *configWithSeedStruct) GetAge() *sync.Int64 { return &c.Age }
 
 type configWithoutSeedStruct struct {
 	Age sync.Int64 `flag:"age"`
 }
 
-func (c configWithoutSeedStruct) GetAge() sync.Int64 { return c.Age }
+func (c *configWithoutSeedStruct) GetAge() *sync.Int64 { return &c.Age }
 
 func TestSeeder_Seed_Flags(t *testing.T) {
-	// configWithSeed, err := config.New(&configWithSeedStruct{})
-	// require.NoError(t, err)
-	// configWithoutSeed, err := config.New(&configWithoutSeedStruct{})
-	// require.NoError(t, err)
-
 	// Each test can alter os.Args, so we need to reset it manually with their original value.
 	originalArgs := []string{}
-	for _, arg := range os.Args {
-		originalArgs = append(originalArgs, arg)
-	}
+	originalArgs = append(originalArgs, os.Args...)
 
 	testCases := []struct {
 		desc         string
@@ -126,9 +119,7 @@ func TestSeeder_Seed_Flags(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			os.Args = originalArgs
-			for _, extraCliArg := range tC.extraCliArgs {
-				os.Args = append(os.Args, extraCliArg)
-			}
+			os.Args = append(os.Args, tC.extraCliArgs...)
 
 			seeder := New()
 			cfg, err := config.New(tC.inputConfig)


### PR DESCRIPTION
## Which problem is this PR solving?
Resolves #24 (flag support) and allows developers to use flag-seeded values.

Now possible (from `examples/01_basic`):

```
type config struct {
	Name sync.String `seed:"John Doe"`
	Age  sync.Int64  `seed:"18" env:"ENV_AGE"`
	City sync.String `seed:"London" flag:"city"`
}
```

Running `./ go run examples/01_basic/main.go -city=Athens` will set `config.City` to `"Athens"`.

## Short description of the changes

* Add a new `SourceFlag`
* Add support for `SourceFlag`
* Update doc
* Fix PR template links

Please see the code in `seed.go`, where you can find additional comments about my choices.

Note: the most important choice I made is to ignore errors when parsing flags, so that any argument which is not expected to be parsed as a flag-seeded value will simply be ignored instead of returning an error.