### PR TITLE
Vault support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ The order is applied as it is listed above. Consul seeder and monitor are option
 
 ```go
 type Config struct {
-    Name    sync.String  `seed:"John Doe"`
-    Age     sync.Int64   `seed:"18" env:"ENV_AGE"`
-    City    sync.String  `seed:"London" flag:"city"`
-    IsAdmin sync.Bool    `seed:"true" env:"ENV_IS_ADMIN" consul:"/config/is-admin"`
+    Name    sync.String   `seed:"John Doe"`
+    Age     sync.Int64    `seed:"18" env:"ENV_AGE"`
+    City    sync.String   `seed:"London" flag:"city"`
+    IsAdmin sync.Bool     `seed:"true" env:"ENV_IS_ADMIN" consul:"/config/is-admin"`
+    AppSecret sync.String `seed:"secret" vault:"secret/data/path/to/secret/secret-key"`
 }
 ```
 
@@ -29,6 +30,7 @@ The above defines the following fields:
 - Age, which will be seeded with the value `18`, and if exists, overridden with whatever value the env var `ENV_AGE` holds
 - City, which will be seeded with the value `London`, and if exists, overridden with whatever value the flag `city` holds
 - IsAdmin, which will be seeded with the value `true`, and if exists, overridden with whatever value the env var `ENV_AGE` holds and then from consul if the consul seeder and/or watcher are provided.
+- AppSecret, which will be seeded with the value `secret`, and if exists, overriden with the secret value contained in Vault at the path `secret/data/path/to/secret` with the key `secret-key`.
 
 The fields have to be one of the types that the sync package supports in order to allow concurrent read and write to the fields. The following types are supported:
 
@@ -43,8 +45,9 @@ The fields have to be one of the types that the sync package supports in order t
   
 - Apply the seed tag value, if present
 - Apply the value contained in the env var, if present
-- Apply the value returned from Consul, if present and harvester is setup to seed from consul
 - Apply the value contained in the CLI flags, if present
+- Apply the value contained in Vault, if present
+- Apply the value returned from Consul, if present and harvester is setup to seed from consul
 
 Conditions where seeding fails:
 
@@ -80,17 +83,19 @@ This feature have to be setup when creating a `Harvester` with the builder.
 
 The `Harvester` builder pattern is used to create a `Harvester` instance. The builder supports setting up:
 
+- Vault seed, for setting up seeding from Vault
 - Consul seed, for setting up seeding from Consul
 - Consul monitor, for setting up monitoring from Consul
 
 ```go
     h, err := New(&cfg).
-                WithConsulSeed("address", "dc", "token").
-                WithConsulMonitor("address", "dc", "token", items...).
+                WithVaultSeed("address", "token", 60*time.Second).
+                WithConsulSeed("address", "dc", "token", 60*time.Second).
+                WithConsulMonitor("address", "dc", "token", 60*time.Second, items...).
                 Create()
 ```
 
-The above snippet set's up a `Harvester` instance with consul seed and monitor.
+The above snippet set's up a `Harvester` instance with Vault seed, Consul seed and Consul monitor.
 
 ## Consul
 

--- a/config/config.go
+++ b/config/config.go
@@ -58,15 +58,13 @@ func NewField(fld *reflect.StructField, val *reflect.Value) (*Field, error) {
 	if ok {
 		f.sources[SourceConsul] = value
 	}
-<<<<<<< HEAD
-	value, ok = fld.Tag.Lookup(string(SourceVault))
-	if ok {
-		f.sources[SourceVault] = value
-=======
 	value, ok = fld.Tag.Lookup(string(SourceFlag))
 	if ok {
 		f.sources[SourceFlag] = value
->>>>>>> master
+	}
+	value, ok = fld.Tag.Lookup(string(SourceVault))
+	if ok {
+		f.sources[SourceVault] = value
 	}
 	return f, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,8 @@ const (
 	SourceEnv Source = "env"
 	// SourceConsul defines a value from consul.
 	SourceConsul Source = "consul"
+	// SourceVault defines a value from Vault.
+	SourceVault Source = "vault"
 )
 
 // Field definition of a config value that can change.
@@ -53,6 +55,10 @@ func NewField(fld *reflect.StructField, val *reflect.Value) (*Field, error) {
 	value, ok = fld.Tag.Lookup(string(SourceConsul))
 	if ok {
 		f.sources[SourceConsul] = value
+	}
+	value, ok = fld.Tag.Lookup(string(SourceVault))
+	if ok {
+		f.sources[SourceVault] = value
 	}
 	return f, nil
 }

--- a/examples/04_vault/docker-compose.yml
+++ b/examples/04_vault/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+services:
+  vault:
+    image: vault:latest
+    ports:
+      - 8200:8200
+    environment:
+      - VAULT_API_ADDR=http://127.0.0.1:8200
+      - VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200
+      - VAULT_DEV_ROOT_TOKEN_ID=root
+    cap_add:
+      - IPC_LOCK
+    command: vault server -dev

--- a/examples/04_vault/docker-compose.yml
+++ b/examples/04_vault/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   vault:
-    image: vault:latest
+    image: vault:1.1.3
     ports:
       - 8200:8200
     environment:

--- a/examples/04_vault/main.go
+++ b/examples/04_vault/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/beatlabs/harvester"
+	"github.com/beatlabs/harvester/sync"
+	"github.com/hashicorp/vault/api"
+)
+
+type config struct {
+	Secret sync.String `vault:"secret/data/harvester/example_04/app_secret"`
+}
+
+func main() {
+	ctx, cnl := context.WithCancel(context.Background())
+	defer cnl()
+
+	address := "http://0.0.0.0:8200"
+	token := "root"
+	createSecretInVault(address, token, "secret/data/harvester/example_04", "app_secret", "@pps3cr3t")
+
+	cfg := config{}
+	h, err := harvester.New(&cfg).
+		WithVaultSeed(address, token, 0).
+		Create()
+	if err != nil {
+		log.Fatalf("failed to create harvester: %v", err)
+	}
+
+	err = h.Harvest(ctx)
+	if err != nil {
+		log.Fatalf("failed to harvest configuration: %v", err)
+	}
+
+	log.Printf("Secret: %s", cfg.Secret.Get())
+}
+
+func createSecretInVault(address, token, path, secretKey, secretValue string) {
+	cfg := api.DefaultConfig()
+	cfg.Address = address
+	cfg.Timeout = 5 * time.Second
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		log.Fatalf("failed to create Vault client: %v", err)
+	}
+	client.SetToken(token)
+
+	_, err = client.Logical().Delete(path)
+	if err != nil {
+		log.Fatalf("could not reset Vault key: %v", err)
+	}
+
+	_, err = client.Logical().Write(
+		path,
+		map[string]interface{}{
+			"data": map[string]interface{}{secretKey: secretValue},
+		},
+	)
+	if err != nil {
+		log.Fatalf("could not write Vault key: %v", err)
+	}
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,13 @@ A fast way to get consul is the following:
     unzip "consul_1.4.3_linux_amd64.zip"
     ./consul agent -server -bootstrap-expect 1 -data-dir /tmp/consul -dev -bind=$(hostname -I | awk '{print $1}' | xargs) -http-port 8500
 
+For example `04_vault`, it is possible to run Vault with Docker Compose (https://docs.docker.com/compose/install/) using
+the file `examples/04_vault/docker-compose.yml`:
+
+    cd examples/04_vault
+    docker-compose up -d
+    go run main.go
+
 ## 01 Basic usage with env vars
 
     go run examples/01_basic/main.go
@@ -42,3 +49,11 @@ A fast way to get consul is the following:
     2019/06/04 22:05:32 INFO: consul value 123.45 applied on Balance
     2019/06/04 22:05:32 Config: Name: John Doe, Age: 18, Balance: 123.450000
     2019/06/04 22:05:34 Config: Name: John Doe, Age: 18, Balance: 999.990000
+
+## 04 Seed values from Vault
+
+    go run examples/04_vault/main.go
+
+    2019/07/18 13:45:45 INFO: field Secret updated with value @pps3cr3t, version: 0
+    2019/07/18 13:45:45 INFO: vault value @pps3cr3t applied on field Secret
+    2019/07/18 13:45:45 Secret: @pps3cr3t

--- a/harvester.go
+++ b/harvester.go
@@ -99,7 +99,7 @@ func (b *Builder) WithConsulMonitor(addr, dc, token string, timeout time.Duratio
 	return b
 }
 
-// WithVaultSeed enables support for seeding values with Vault.
+// WithVaultSeed enables support for seeding values with Vault. It currently only supports token authentication.
 func (b *Builder) WithVaultSeed(addr, token string, timeout time.Duration) *Builder {
 	if b.err != nil {
 		return b

--- a/harvester.go
+++ b/harvester.go
@@ -9,6 +9,7 @@ import (
 	"github.com/beatlabs/harvester/monitor/consul"
 	"github.com/beatlabs/harvester/seed"
 	seedConsul "github.com/beatlabs/harvester/seed/consul"
+	seedVault "github.com/beatlabs/harvester/seed/vault"
 )
 
 // Seeder interface for seeding initial values of the configuration.
@@ -95,6 +96,25 @@ func (b *Builder) WithConsulMonitor(addr, dc, token string, timeout time.Duratio
 		return b
 	}
 	b.watchers = append(b.watchers, wtc)
+	return b
+}
+
+// WithVaultSeed enables support for seeding values with Vault.
+func (b *Builder) WithVaultSeed(addr, token string, timeout time.Duration) *Builder {
+	if b.err != nil {
+		return b
+	}
+	getter, err := seedVault.New(addr, token, timeout)
+	if err != nil {
+		b.err = err
+		return b
+	}
+	p, err := seed.NewParam(config.SourceVault, getter)
+	if err != nil {
+		b.err = err
+		return b
+	}
+	b.seedParams = append(b.seedParams, *p)
 	return b
 }
 

--- a/seed/vault/getter.go
+++ b/seed/vault/getter.go
@@ -15,23 +15,24 @@ type Getter struct {
 	client *api.Client
 }
 
-// New constructor. Timeout is set to 60s when 0 is provided
+// New creates a new Getter. Timeout defaults to 60s.
 func New(addr, token string, timeout time.Duration) (*Getter, error) {
+	if addr == "" {
+		return nil, errors.New("address is empty")
+	}
+	if timeout <= 0 {
+		timeout = 60 * time.Second
+	}
+
 	client, err := newClient(addr, token, timeout)
 	if err != nil {
 		return nil, err
 	}
+
 	return &Getter{client: client}, nil
 }
 
 func newClient(addr, token string, timeout time.Duration) (*api.Client, error) {
-	if addr == "" {
-		return nil, errors.New("address is empty")
-	}
-	if timeout == 0 {
-		timeout = 60 * time.Second
-	}
-
 	config := api.DefaultConfig()
 	config.Address = addr
 

--- a/seed/vault/getter.go
+++ b/seed/vault/getter.go
@@ -1,0 +1,111 @@
+package vault
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+)
+
+// Getter implementation of the getter interface.
+type Getter struct {
+	client *api.Client
+}
+
+// New constructor. Timeout is set to 60s when 0 is provided
+func New(addr, token string, timeout time.Duration) (*Getter, error) {
+	client, err := newClient(addr, token, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return &Getter{client: client}, nil
+}
+
+func newClient(addr, token string, timeout time.Duration) (*api.Client, error) {
+	if addr == "" {
+		return nil, errors.New("address is empty")
+	}
+	if timeout == 0 {
+		timeout = 60 * time.Second
+	}
+
+	config := api.DefaultConfig()
+	config.Address = addr
+
+	client, err := api.NewClient(config)
+	if err != nil {
+		return nil, err
+	}
+	client.SetToken(token)
+
+	return client, nil
+}
+
+// Get the specific key value from Vault.
+func (g *Getter) Get(key string) (*string, uint64, error) {
+	path, secretKey, err := g.splitKey(key)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	secret, err := g.client.Logical().Read(path)
+	if err != nil {
+		return nil, 0, err
+	}
+	if secret == nil {
+		return nil, 0, nil
+	}
+
+	data, ok := secret.Data["data"]
+	if !ok {
+		return nil, 0, fmt.Errorf("could not fetch Vault secret data at path: %s", path)
+	}
+
+	secrets, ok := data.(map[string]interface{})
+	if !ok {
+		return nil, 0, fmt.Errorf("invalid data stored in Vault at path: %s", path)
+	}
+
+	secretValue, ok := secrets[secretKey]
+	if !ok {
+		return nil, 0, fmt.Errorf("no Vault secret could be found at path %s with key %s", path, secretKey)
+	}
+
+	var secretValueString string
+
+	switch value := secretValue.(type) {
+	case json.Number:
+		secretValueString = value.String()
+	case string:
+		secretValueString = value
+	case bool:
+		if value {
+			secretValueString = "true"
+		} else {
+			secretValueString = "false"
+		}
+	default:
+		return nil, 0, fmt.Errorf("unsupported data type stored in Vault at path %s with key %s (%T found)", path, secretKey, value)
+	}
+
+	return &secretValueString, 0, nil
+}
+
+// splitKey splits a given key and returns the Vault path plus the key inside the path.
+// Example: splitKey("/path/to/the/key/the-key") will return ("path/to/the/key", "the-key", nil)
+// Returns an error if the key cannot be split.
+func (g *Getter) splitKey(key string) (string, string, error) {
+	parts := strings.Split(
+		strings.Trim(key, "/"),
+		"/",
+	)
+
+	if len(parts) <= 1 {
+		return "", "", fmt.Errorf("malformed key: %s", key)
+	}
+
+	return strings.Join(parts[:len(parts)-1], "/"), parts[len(parts)-1], nil
+}

--- a/seed/vault/getter_integration_test.go
+++ b/seed/vault/getter_integration_test.go
@@ -1,0 +1,136 @@
+// +build integration
+
+package vault
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	addr    = "http://0.0.0.0:8200"
+	token   = "root"
+	timeout = 5 * time.Second
+)
+
+func Test_Get_From_Vault(t *testing.T) {
+	client, err := newClient(addr, token, timeout)
+	require.NoError(t, err)
+
+	basePath := "secret/data/harvester/test/getter"
+	deleteSecretsAtPath(t, client, basePath)
+
+	getter := newGetter(t)
+
+	writeSecret(t, client, basePath, map[string]interface{}{
+		"string":        "foo",
+		"integer":       42,
+		"float":         13.37,
+		"boolean-true":  true,
+		"boolean-false": false,
+		"slice":         []interface{}{"foo", "bar"},
+	})
+
+	testCases := []struct {
+		desc          string
+		key           string
+		expectedValue *string
+		expectedErr   error
+	}{
+		{
+			desc:        "Malformed key",
+			key:         "/something",
+			expectedErr: errors.New("malformed key: /something"),
+		},
+		{
+			desc:          "Unexisting key",
+			key:           "something/that/does/not/exist",
+			expectedValue: nil,
+			expectedErr:   nil,
+		},
+		{
+			desc:          "Unexisting secret within key",
+			key:           fmt.Sprintf("%s/something", basePath),
+			expectedValue: nil,
+			expectedErr:   fmt.Errorf("no Vault secret could be found at path %s with key something", basePath),
+		},
+		{
+			desc:          "Unsupported data type",
+			key:           fmt.Sprintf("%s/slice", basePath),
+			expectedValue: nil,
+			expectedErr:   fmt.Errorf("unsupported data type stored in Vault at path %s with key slice ([]interface {} found)", basePath),
+		},
+		{
+			desc:          "String value",
+			key:           fmt.Sprintf("%s/string", basePath),
+			expectedValue: pointerToString("foo"),
+		},
+		{
+			desc:          "Integer value",
+			key:           fmt.Sprintf("%s/integer", basePath),
+			expectedValue: pointerToString("42"),
+		},
+		{
+			desc:          "Float value",
+			key:           fmt.Sprintf("%s/float", basePath),
+			expectedValue: pointerToString("13.37"),
+		},
+		{
+			desc:          "Boolean value (true)",
+			key:           fmt.Sprintf("%s/boolean-true", basePath),
+			expectedValue: pointerToString("true"),
+		},
+		{
+			desc:          "Boolean value (false)",
+			key:           fmt.Sprintf("%s/boolean-false", basePath),
+			expectedValue: pointerToString("false"),
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			foundValue, version, err := getter.Get(tC.key)
+
+			if tC.expectedErr != nil {
+				assert.Nil(t, foundValue)
+				assert.Equal(t, uint64(0), version)
+				assert.EqualError(t, err, tC.expectedErr.Error())
+			} else {
+				assert.Equal(t, tC.expectedValue, foundValue)
+				assert.Equal(t, uint64(0), version)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func newGetter(t *testing.T) *Getter {
+	// TODO: this should move to env-based vars...
+	getter, err := New(addr, token, timeout)
+	require.NoError(t, err)
+	return getter
+}
+
+func deleteSecretsAtPath(t *testing.T, client *api.Client, path string) {
+	_, err := client.Logical().Delete(path)
+	require.NoError(t, err)
+}
+
+func writeSecret(t *testing.T, client *api.Client, path string, data map[string]interface{}) {
+	_, err := client.Logical().Write(
+		path,
+		map[string]interface{}{
+			"data": data,
+		},
+	)
+	require.NoError(t, err)
+}
+
+func pointerToString(s string) *string {
+	return &s
+}

--- a/seed/vault/getter_test.go
+++ b/seed/vault/getter_test.go
@@ -1,0 +1,107 @@
+package vault
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_New(t *testing.T) {
+	testCases := []struct {
+		desc        string
+		address     string
+		token       string
+		timeout     time.Duration
+		expectedErr error
+	}{
+		{
+			desc:        "Empty address",
+			address:     "",
+			expectedErr: errors.New("address is empty"),
+		},
+		{
+			desc:        "Proper creation without timeout",
+			address:     "something",
+			token:       "token",
+			timeout:     0,
+			expectedErr: nil,
+		},
+		{
+			desc:        "Proper creation with a timeout",
+			address:     "someting",
+			token:       "token",
+			timeout:     5 * time.Second,
+			expectedErr: nil,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			getter, err := New(tC.address, tC.token, tC.timeout)
+
+			if tC.expectedErr != nil {
+				assert.EqualError(t, err, tC.expectedErr.Error())
+				assert.Nil(t, getter)
+			} else {
+				assert.NoError(t, err)
+				assert.IsType(t, &Getter{}, getter)
+			}
+		})
+	}
+}
+
+func Test_Getter_Split_Key(t *testing.T) {
+	testCases := []struct {
+		desc         string
+		inputKey     string
+		expectedPath string
+		expectedKey  string
+		expectedErr  error
+	}{
+		{
+			desc:        "Malformed key",
+			inputKey:    "something",
+			expectedErr: errors.New("malformed key: something"),
+		},
+		{
+			desc:        "Malformed key with leading slash",
+			inputKey:    "/something",
+			expectedErr: errors.New("malformed key: /something"),
+		},
+		{
+			desc:        "Malformed key with trailing slash",
+			inputKey:    "something/",
+			expectedErr: errors.New("malformed key: something/"),
+		},
+		{
+			desc:         "Proper key (short)",
+			inputKey:     "path-to-the-key/the-key",
+			expectedPath: "path-to-the-key",
+			expectedKey:  "the-key",
+			expectedErr:  nil,
+		},
+		{
+			desc:         "Proper key (long)",
+			inputKey:     "path/to/the/key/the-key",
+			expectedPath: "path/to/the/key",
+			expectedKey:  "the-key",
+			expectedErr:  nil,
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			getter := &Getter{}
+			path, key, err := getter.splitKey(tC.inputKey)
+			if tC.expectedErr != nil {
+				assert.Equal(t, "", path)
+				assert.Equal(t, "", key)
+				assert.EqualError(t, err, tC.expectedErr.Error())
+			} else {
+				assert.Equal(t, tC.expectedPath, path)
+				assert.Equal(t, tC.expectedKey, key)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Which problem is this PR solving?

Adds support for Vault (resolves #26).

## Short description of the changes

* Add support for Vault (only through token auth for now)
* Add example
* Add tests
* Update README

Note: the current Vault implementation supports Vault keys with the following format: `path/to/the/secret/the-secret-key`.

## Example

Given Vault configured like this (in the UI):

Path: `aws/db-credentials`
```json
{
    "id": "foo",
    "pwd": "bar"
}
```

And a config configured like this:

```go
type config struct {
	DbId sync.String  `vault:"secret/data/aws/db-credentials/id"`
	DbPwd sync.String `vault:"secret/data/aws/db-credentials/pwd"`
}
```

Then after seeding, we will have the following values:

```
config.DbId.Get() => "foo"
config.DbId.Get() => "bar"
```