### PR TITLE
Update go.mod file for apache thrift, closes #30

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/beatlabs/harvester
 
 go 1.12
 
+replace git.apache.org/thrift.git => github.com/apache/thrift v0.12.0
+
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 // indirect
 	github.com/Microsoft/go-winio v0.4.12 // indirect


### PR DESCRIPTION
* Update go mod file to dictate the change of the source of apache thrift package.

## Which problem is this PR solving?
This resolves issue # 30

## Short description of the changes
Add a go mod replace command to dictate the updated source of apache/thrift