### PR TITLE
Provide ability to have nested config structs

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,8 +33,8 @@ type Field struct {
 	sources map[Source]string
 }
 
-// NewField constructor.
-func NewField(prefix string, fld *reflect.StructField, val *reflect.Value) (*Field, error) {
+// newField constructor.
+func newField(prefix string, fld *reflect.StructField, val *reflect.Value) (*Field, error) {
 	if !isTypeSupported(fld.Type) {
 		return nil, fmt.Errorf("field %s is not supported (only types from the sync package of harvester)", fld.Name)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,8 @@ const (
 	SourceFlag Source = "flag"
 )
 
+var sourceTags = [...]Source{SourceSeed, SourceEnv, SourceConsul, SourceFlag}
+
 // Field definition of a config value that can change.
 type Field struct {
 	name    string
@@ -34,35 +36,24 @@ type Field struct {
 }
 
 // newField constructor.
-func newField(prefix string, fld *reflect.StructField, val *reflect.Value) (*Field, error) {
-	if !isTypeSupported(fld.Type) {
-		return nil, fmt.Errorf("field %s is not supported (only types from the sync package of harvester)", fld.Name)
-	}
+func newField(prefix string, fld reflect.StructField, val reflect.Value) *Field {
 	f := &Field{
 		name:    prefix + fld.Name,
 		tp:      fld.Type.Name(),
 		version: 0,
-		setter:  val.FieldByName(fld.Name).Addr().MethodByName("Set"),
-		printer: val.FieldByName(fld.Name).Addr().MethodByName("String"),
+		setter:  val.Addr().MethodByName("Set"),
+		printer: val.Addr().MethodByName("String"),
 		sources: make(map[Source]string),
 	}
-	value, ok := fld.Tag.Lookup(string(SourceSeed))
-	if ok {
-		f.sources[SourceSeed] = value
+
+	for _, tag := range sourceTags {
+		value, ok := fld.Tag.Lookup(string(tag))
+		if ok {
+			f.sources[tag] = value
+		}
 	}
-	value, ok = fld.Tag.Lookup(string(SourceEnv))
-	if ok {
-		f.sources[SourceEnv] = value
-	}
-	value, ok = fld.Tag.Lookup(string(SourceConsul))
-	if ok {
-		f.sources[SourceConsul] = value
-	}
-	value, ok = fld.Tag.Lookup(string(SourceFlag))
-	if ok {
-		f.sources[SourceFlag] = value
-	}
-	return f, nil
+
+	return f
 }
 
 // Name getter.
@@ -144,19 +135,4 @@ func New(cfg interface{}) (*Config, error) {
 	}
 
 	return &Config{Fields: ff}, nil
-}
-
-func isTypeSupported(t reflect.Type) bool {
-	if t.Kind() != reflect.Struct {
-		return false
-	}
-	if t.PkgPath() != "github.com/beatlabs/harvester/sync" {
-		return false
-	}
-	switch t.Name() {
-	case "Bool", "Int64", "Float64", "String", "Secret":
-		return true
-	default:
-		return false
-	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -138,7 +138,7 @@ func New(cfg interface{}) (*Config, error) {
 		return nil, errors.New("configuration is nil")
 	}
 
-	ff, err := newParser().GetFields(cfg)
+	ff, err := newParser().ParseCfg(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -58,6 +58,7 @@ func TestNew(t *testing.T) {
 		{name: "cfg is not pointer", args: args{cfg: testConfig{}}, wantErr: true},
 		{name: "cfg field not supported", args: args{cfg: &testInvalidTypeConfig{}}, wantErr: true},
 		{name: "cfg duplicate consul key", args: args{cfg: &testDuplicateConfig{}}, wantErr: true},
+		{name: "cfg nested duplicate consul key", args: args{cfg: &testDuplicateNestedConsulConfig{}}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -68,7 +69,7 @@ func TestNew(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, got)
-				assert.Len(t, got.Fields, 4)
+				assert.Len(t, got.Fields, 5)
 				assertField(t, got.Fields[0], "Name", "String",
 					map[Source]string{SourceSeed: "John Doe", SourceEnv: "ENV_NAME"})
 				assertField(t, got.Fields[1], "Age", "Int64",
@@ -77,6 +78,8 @@ func TestNew(t *testing.T) {
 					map[Source]string{SourceSeed: "99.9", SourceEnv: "ENV_BALANCE", SourceConsul: "/config/balance"})
 				assertField(t, got.Fields[3], "HasJob", "Bool",
 					map[Source]string{SourceSeed: "true", SourceEnv: "ENV_HAS_JOB", SourceConsul: "/config/has-job"})
+				assertField(t, got.Fields[4], "PositionSalary", "Int64",
+					map[Source]string{SourceSeed: "2000", SourceEnv: "ENV_SALARY"})
 			}
 		})
 	}
@@ -90,7 +93,7 @@ func assertField(t *testing.T, fld *Field, name, typ string, sources map[Source]
 }
 
 func TestConfig_Set(t *testing.T) {
-	c := testConfig{}
+	c := testConfig{Position2: &testNestedConfig{}}
 	cfg, err := New(&c)
 	require.NoError(t, err)
 	err = cfg.Fields[0].Set("John Doe", 1)
@@ -101,17 +104,36 @@ func TestConfig_Set(t *testing.T) {
 	assert.NoError(t, err)
 	err = cfg.Fields[3].Set("true", 1)
 	assert.NoError(t, err)
+	err = cfg.Fields[4].Set("6000", 1)
+	assert.NoError(t, err)
+	err = cfg.Fields[5].Set("7000", 1)
+	assert.NoError(t, err)
 	assert.Equal(t, "John Doe", c.Name.Get())
 	assert.Equal(t, int64(18), c.Age.Get())
 	assert.Equal(t, 99.9, c.Balance.Get())
 	assert.Equal(t, true, c.HasJob.Get())
+	assert.Equal(t, int64(6000), c.Position.Salary.Get())
+	assert.Equal(t, int64(7000), c.Position2.Salary.Get())
+}
+
+type testNestedConfig struct {
+	Salary sync.Int64 `seed:"2000" env:"ENV_SALARY"`
 }
 
 type testConfig struct {
-	Name    sync.String  `seed:"John Doe" env:"ENV_NAME"`
-	Age     sync.Int64   `env:"ENV_AGE" consul:"/config/age"`
-	Balance sync.Float64 `seed:"99.9" env:"ENV_BALANCE" consul:"/config/balance"`
-	HasJob  sync.Bool    `seed:"true" env:"ENV_HAS_JOB" consul:"/config/has-job"`
+	Name      sync.String  `seed:"John Doe" env:"ENV_NAME"`
+	Age       sync.Int64   `env:"ENV_AGE" consul:"/config/age"`
+	Balance   sync.Float64 `seed:"99.9" env:"ENV_BALANCE" consul:"/config/balance"`
+	HasJob    sync.Bool    `seed:"true" env:"ENV_HAS_JOB" consul:"/config/has-job"`
+	Position  testNestedConfig
+	Position2 *testNestedConfig
+}
+
+type testDuplicateNestedConsulConfig struct {
+	Age1   sync.Int64 `env:"ENV_AGE" consul:"/config/age"`
+	Nested struct {
+		Age2 sync.Int64 `env:"ENV_AGE" consul:"/config/age"`
+	}
 }
 
 type testInvalidTypeConfig struct {

--- a/config/parser.go
+++ b/config/parser.go
@@ -55,7 +55,7 @@ func (p *parser) getFields(prefix string, tp reflect.Type, val *reflect.Value) (
 
 func (p *parser) getNestedFields(prefix string, sf reflect.StructField, val reflect.Value) ([]*Field, error) {
 	if val.Type().Kind() == reflect.Ptr && val.IsNil() {
-		return make([]*Field, 0), nil
+		return nil, fmt.Errorf("value can not be nil for %s", sf.Name)
 	}
 
 	typ := val.Type()

--- a/config/parser.go
+++ b/config/parser.go
@@ -1,0 +1,89 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+)
+
+type parser struct {
+	dups map[Source]string
+}
+
+func newParser() *parser {
+	return &parser{}
+}
+
+func (p *parser) GetFields(cfg interface{}) ([]*Field, error) {
+	p.dups = make(map[Source]string)
+
+	tp := reflect.TypeOf(cfg)
+	if tp.Kind() != reflect.Ptr {
+		return nil, errors.New("configuration should be a pointer type")
+	}
+	val := reflect.ValueOf(cfg).Elem()
+
+	return p.getFields("", tp.Elem(), &val)
+}
+
+func (p *parser) getFields(prefix string, tp reflect.Type, val *reflect.Value) ([]*Field, error) {
+	var ff []*Field
+	for i := 0; i < tp.NumField(); i++ {
+		f := tp.Field(i)
+		fld, err := NewField(prefix, &f, val)
+		if err != nil {
+			if !p.isNestedTypeSupported(f.Type) {
+				return nil, err
+			}
+			nested, err := p.getNestedFields(prefix, f, val.Field(i))
+			if err != nil {
+				return nil, err
+			}
+			ff = append(ff, nested...)
+			continue
+		}
+		value, ok := fld.Sources()[SourceConsul]
+		if ok {
+			if p.isKeyValueDuplicate(SourceConsul, value) {
+				return nil, fmt.Errorf("duplicate value %v for source %s", fld, SourceConsul)
+			}
+		}
+		ff = append(ff, fld)
+	}
+	return ff, nil
+}
+
+func (p *parser) getNestedFields(prefix string, sf reflect.StructField, val reflect.Value) ([]*Field, error) {
+	if val.Type().Kind() == reflect.Ptr && val.IsNil() {
+		return make([]*Field, 0), nil
+	}
+
+	typ := val.Type()
+	if typ.Kind() == reflect.Ptr {
+		typ = typ.Elem()
+		val = val.Elem()
+	}
+
+	return p.getFields(prefix+sf.Name, typ, &val)
+}
+
+func (p *parser) isNestedTypeSupported(t reflect.Type) bool {
+	if t.Kind() == reflect.Struct {
+		return true
+	}
+	if t.Kind() == reflect.Ptr && t.Elem().Kind() == reflect.Struct {
+		return true
+	}
+	return false
+}
+
+func (p *parser) isKeyValueDuplicate(src Source, value string) bool {
+	v, ok := p.dups[src]
+	if ok {
+		if value == v {
+			return true
+		}
+	}
+	p.dups[src] = value
+	return false
+}

--- a/config/parser.go
+++ b/config/parser.go
@@ -14,7 +14,7 @@ func newParser() *parser {
 	return &parser{}
 }
 
-func (p *parser) GetFields(cfg interface{}) ([]*Field, error) {
+func (p *parser) ParseCfg(cfg interface{}) ([]*Field, error) {
 	p.dups = make(map[Source]string)
 
 	tp := reflect.TypeOf(cfg)

--- a/config/parser.go
+++ b/config/parser.go
@@ -30,7 +30,7 @@ func (p *parser) getFields(prefix string, tp reflect.Type, val *reflect.Value) (
 	var ff []*Field
 	for i := 0; i < tp.NumField(); i++ {
 		f := tp.Field(i)
-		fld, err := NewField(prefix, &f, val)
+		fld, err := newField(prefix, &f, val)
 		if err != nil {
 			if !p.isNestedTypeSupported(f.Type) {
 				return nil, err

--- a/harvester_test.go
+++ b/harvester_test.go
@@ -61,6 +61,7 @@ func TestCreate_NoConsul(t *testing.T) {
 	assert.Equal(t, 99.9, cfg.Balance.Get())
 	assert.Equal(t, true, cfg.HasJob.Get())
 	assert.Equal(t, int64(8000), cfg.Position.Salary.Get())
+	assert.Equal(t, int64(24), cfg.Position.Place.RoomNumber.Get())
 }
 
 func TestCreate_SeedError(t *testing.T) {
@@ -88,6 +89,9 @@ type testConfigNoConsul struct {
 	HasJob   sync.Bool    `seed:"true"`
 	Position struct {
 		Salary sync.Int64 `seed:"8000"`
+		Place  struct {
+			RoomNumber sync.Int64 `seed:"24"`
+		}
 	}
 }
 

--- a/harvester_test.go
+++ b/harvester_test.go
@@ -60,6 +60,7 @@ func TestCreate_NoConsul(t *testing.T) {
 	assert.Equal(t, int64(18), cfg.Age.Get())
 	assert.Equal(t, 99.9, cfg.Balance.Get())
 	assert.Equal(t, true, cfg.HasJob.Get())
+	assert.Equal(t, int64(8000), cfg.Position.Salary.Get())
 }
 
 func TestCreate_SeedError(t *testing.T) {
@@ -81,10 +82,13 @@ type testConfig struct {
 }
 
 type testConfigNoConsul struct {
-	Name    sync.String  `seed:"John Doe"`
-	Age     sync.Int64   `seed:"18"`
-	Balance sync.Float64 `seed:"99.9"`
-	HasJob  sync.Bool    `seed:"true"`
+	Name     sync.String  `seed:"John Doe"`
+	Age      sync.Int64   `seed:"18"`
+	Balance  sync.Float64 `seed:"99.9"`
+	HasJob   sync.Bool    `seed:"true"`
+	Position struct {
+		Salary sync.Int64 `seed:"8000"`
+	}
 }
 
 type testConfigSeedError struct {


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #16 providing ability to have nested configuration structures.

Now it is possible to create complex configuration structures, for example (tags have been omitted for simplicity):

```go
type NestedConfig struct {
	SomeField sync.Int64
}

type Cfg struct {
	Foo sync.String
	Bar struct {
		Baz sync.String
	}
	Nested NestedConfig
}

c := Cfg{}

// ... instantiate and use harvester as usual

```

## Short description of the changes

1. Functionality for creating Fields from configuration struct was moved from `config.go` to the dedicated `parser` struct to handle consul keys duplication centrally and to group one-purpose functions in one place
2. Added processing of nested structures with the following logic:
    - It is possible to nest structures by value of by reference
    - If nested struct is referenced by `nil` it returns error
    - To prevent confusion with possibly equal Field names in different nested structs, it prefixes target field name with parent struct field name.
4. Unit tests was extended to check nested structs behaviour

Resulting Fields array has remained flat, so these changes should not affect other parts of the library

### Example with nested struct and fields naming

Parsing of the following struct (seeding tags have been omitted for simplicity):

```go
type Cfg struct {
	Foo sync.String
	Bar struct {
		Foo sync.String
	}
}
```

will end up with two resulting Fields: `Foo` and `BarFoo`


