### PR TITLE
Feature user types

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ const (
 
 var sourceTags = [...]Source{SourceSeed, SourceEnv, SourceConsul, SourceFlag}
 
+// CfgType represents an interface which any config field type must implement.
 type CfgType interface {
 	fmt.Stringer
 	SetString(string) error

--- a/config/config.go
+++ b/config/config.go
@@ -24,9 +24,9 @@ const (
 
 var sourceTags = [...]Source{SourceSeed, SourceEnv, SourceConsul, SourceFlag}
 
-type StructField interface {
+type CfgType interface {
+	fmt.Stringer
 	SetString(string) error
-	String() string
 }
 
 // Field definition of a config value that can change.
@@ -34,22 +34,17 @@ type Field struct {
 	name        string
 	tp          string
 	version     uint64
-	structField StructField
+	structField CfgType
 	sources     map[Source]string
 }
 
 // newField constructor.
 func newField(prefix string, fld reflect.StructField, val reflect.Value) *Field {
-	sf, ok := val.Addr().Interface().(StructField)
-	if !ok {
-		return nil, fmt.Errorf("field %s should implement StructField interface", fld.Name)
-	}
-
 	f := &Field{
-		name:        fld.Name,
+		name:        prefix + fld.Name,
 		tp:          fld.Type.Name(),
 		version:     0,
-		structField: sf,
+		structField: val.Addr().Interface().(CfgType),
 		sources:     make(map[Source]string),
 	}
 

--- a/config/custom_type_test.go
+++ b/config/custom_type_test.go
@@ -1,0 +1,65 @@
+package config_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/beatlabs/harvester/config"
+	stdTypes "github.com/beatlabs/harvester/sync"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomField(t *testing.T) {
+	c := &testConfig{}
+	cfg, err := config.New(c)
+	assert.NoError(t, err)
+	err = cfg.Fields[0].Set("expected", 1)
+	assert.NoError(t, err)
+	err = cfg.Fields[1].Set("bar", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "expected", c.CustomValue.Get())
+	assert.Equal(t, "bar", c.SomeString.Get())
+}
+
+func TestErrorValidationOnCustomField(t *testing.T) {
+	c := &testConfig{}
+	cfg, err := config.New(c)
+	assert.NoError(t, err)
+	err = cfg.Fields[0].Set("not_expected", 1)
+	assert.Error(t, err)
+}
+
+type testConcreteValue struct {
+	m     sync.Mutex
+	value string
+}
+
+func (f *testConcreteValue) Set(value string) {
+	f.m.Lock()
+	defer f.m.Unlock()
+	f.value = value
+}
+
+func (f *testConcreteValue) Get() string {
+	f.m.Lock()
+	defer f.m.Unlock()
+	return f.value
+}
+
+func (f *testConcreteValue) String() string {
+	return f.Get()
+}
+
+func (f *testConcreteValue) SetString(value string) error {
+	if value != "expected" {
+		return fmt.Errorf("unable to store provided value")
+	}
+	f.Set(value)
+	return nil
+}
+
+type testConfig struct {
+	CustomValue testConcreteValue `seed:"expected"`
+	SomeString  stdTypes.String   `seed:"foo"`
+}

--- a/config/parser.go
+++ b/config/parser.go
@@ -97,7 +97,7 @@ func (p *parser) getStructFieldType(f reflect.StructField, val reflect.Value) (s
 	for _, tag := range sourceTags {
 		if _, ok := f.Tag.Lookup(string(tag)); ok {
 			if !val.Addr().Type().Implements(cfgType) {
-				return typeInvalid, fmt.Errorf("field %s should implement CfgType interface", f.Name)
+				return typeInvalid, fmt.Errorf("field %s must implement CfgType interface", f.Name)
 			}
 			return typeField, nil
 		}

--- a/config/parser.go
+++ b/config/parser.go
@@ -39,7 +39,7 @@ func (p *parser) getFields(prefix string, tp reflect.Type, val reflect.Value) ([
 	for i := 0; i < tp.NumField(); i++ {
 		f := tp.Field(i)
 
-		typ, err := p.getStructFieldType(f)
+		typ, err := p.getStructFieldType(f, val.Field(i))
 		if err != nil {
 			return nil, err
 		}
@@ -86,16 +86,18 @@ func (p *parser) isKeyValueDuplicate(src Source, value string) bool {
 	return false
 }
 
-func (p *parser) getStructFieldType(f reflect.StructField) (structFieldType, error) {
+func (p *parser) getStructFieldType(f reflect.StructField, val reflect.Value) (structFieldType, error) {
 	t := f.Type
 	if t.Kind() != reflect.Struct {
 		return typeInvalid, fmt.Errorf("only struct type supported for %s", f.Name)
 	}
 
+	cfgType := reflect.TypeOf((*CfgType)(nil)).Elem()
+
 	for _, tag := range sourceTags {
 		if _, ok := f.Tag.Lookup(string(tag)); ok {
-			if t.PkgPath() != "github.com/beatlabs/harvester/sync" {
-				return typeInvalid, fmt.Errorf("field %s is not supported (only types from the sync package of harvester)", f.Name)
+			if !val.Addr().Type().Implements(cfgType) {
+				return typeInvalid, fmt.Errorf("field %s should implement CfgType interface", f.Name)
 			}
 			return typeField, nil
 		}

--- a/examples/05_custom_types/main.go
+++ b/examples/05_custom_types/main.go
@@ -16,7 +16,7 @@ import (
 
 type config struct {
 	IndexName sync.String `seed:"customers-v1"`
-	EMail     EMail       `seed:"foo@example.com" env:"ENV_EMAIL"`
+	Email     Email       `seed:"foo@example.com" env:"ENV_EMAIL"`
 }
 
 func main() {
@@ -40,14 +40,14 @@ func main() {
 		log.Fatalf("failed to harvest configuration: %v", err)
 	}
 
-	log.Printf("Config : IndexName: %s, EMail: %s, EMail.Name: %s, EMail.Domain: %s\n", cfg.IndexName.Get(), cfg.EMail.Get(), cfg.EMail.GetName(), cfg.EMail.GetDomain())
+	log.Printf("Config : IndexName: %s, Email: %s, Email.Name: %s, Email.Domain: %s\n", cfg.IndexName.Get(), cfg.Email.Get(), cfg.Email.GetName(), cfg.Email.GetDomain())
 }
 
 //regex to validate an email value
 const emailPattern = "^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
 
-// EMail represents a custom config structure
-type EMail struct {
+// Email represents a custom config structure
+type Email struct {
 	m      gosync.RWMutex
 	v      string
 	name   string
@@ -55,7 +55,7 @@ type EMail struct {
 }
 
 // SetString performs basic validation and sets a config value from string typed value.
-func (t *EMail) SetString(v string) error {
+func (t *Email) SetString(v string) error {
 	re := regexp.MustCompile(emailPattern)
 	if !re.MatchString(v) {
 		return fmt.Errorf("%s is not a valid email address", v)
@@ -73,7 +73,7 @@ func (t *EMail) SetString(v string) error {
 }
 
 // Get returns the stored value.
-func (t *EMail) Get() string {
+func (t *Email) Get() string {
 	t.m.RLock()
 	defer t.m.RUnlock()
 
@@ -81,7 +81,7 @@ func (t *EMail) Get() string {
 }
 
 // GetName returns name part of the stored email.
-func (t *EMail) GetName() string {
+func (t *Email) GetName() string {
 	t.m.RLock()
 	defer t.m.RUnlock()
 
@@ -89,7 +89,7 @@ func (t *EMail) GetName() string {
 }
 
 // GetDomain returns domain part of the stored email.
-func (t *EMail) GetDomain() string {
+func (t *Email) GetDomain() string {
 	t.m.RLock()
 	defer t.m.RUnlock()
 
@@ -97,6 +97,6 @@ func (t *EMail) GetDomain() string {
 }
 
 // String represents golang Stringer interface.
-func (t *EMail) String() string {
+func (t *Email) String() string {
 	return t.Get()
 }

--- a/examples/05_custom_types/main.go
+++ b/examples/05_custom_types/main.go
@@ -43,10 +43,10 @@ func main() {
 	log.Printf("Config : IndexName: %s, Email: %s, Email.Name: %s, Email.Domain: %s\n", cfg.IndexName.Get(), cfg.Email.Get(), cfg.Email.GetName(), cfg.Email.GetDomain())
 }
 
-//regex to validate an email value
+// regex to validate an email value.
 const emailPattern = "^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
 
-// Email represents a custom config structure
+// Email represents a custom config structure.
 type Email struct {
 	m      gosync.RWMutex
 	v      string

--- a/examples/05_custom_types/main.go
+++ b/examples/05_custom_types/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+
+	gosync "sync"
+
+	"github.com/beatlabs/harvester"
+	"github.com/beatlabs/harvester/sync"
+)
+
+type config struct {
+	IndexName sync.String `seed:"customers-v1"`
+	EMail     EMail       `seed:"foo@example.com" env:"ENV_EMAIL"`
+}
+
+func main() {
+	ctx, cnl := context.WithCancel(context.Background())
+	defer cnl()
+
+	err := os.Setenv("ENV_EMAIL", "bar@example.com")
+	if err != nil {
+		log.Fatalf("failed to set env var: %v", err)
+	}
+
+	cfg := config{}
+
+	h, err := harvester.New(&cfg).Create()
+	if err != nil {
+		log.Fatalf("failed to create harvester: %v", err)
+	}
+
+	err = h.Harvest(ctx)
+	if err != nil {
+		log.Fatalf("failed to harvest configuration: %v", err)
+	}
+
+	log.Printf("Config : IndexName: %s, EMail: %s, EMail.Name: %s, EMail.Domain: %s\n", cfg.IndexName.Get(), cfg.EMail.Get(), cfg.EMail.GetName(), cfg.EMail.GetDomain())
+}
+
+//regex to validate an email value
+const emailPattern = "^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$"
+
+// EMail represents a custom config structure
+type EMail struct {
+	m      gosync.RWMutex
+	v      string
+	name   string
+	domain string
+}
+
+// SetString performs basic validation and sets a config value from string typed value.
+func (t *EMail) SetString(v string) error {
+	re := regexp.MustCompile(emailPattern)
+	if !re.MatchString(v) {
+		return fmt.Errorf("%s is not a valid email address", v)
+	}
+
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	t.v = v
+	parts := strings.Split(v, "@")
+	t.name = parts[0]
+	t.domain = parts[1]
+
+	return nil
+}
+
+// Get returns the stored value.
+func (t *EMail) Get() string {
+	t.m.RLock()
+	defer t.m.RUnlock()
+
+	return t.v
+}
+
+// GetName returns name part of the stored email.
+func (t *EMail) GetName() string {
+	t.m.RLock()
+	defer t.m.RUnlock()
+
+	return t.name
+}
+
+// GetDomain returns domain part of the stored email.
+func (t *EMail) GetDomain() string {
+	t.m.RLock()
+	defer t.m.RUnlock()
+
+	return t.domain
+}
+
+// String represents golang Stringer interface.
+func (t *EMail) String() string {
+	return t.Get()
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -88,3 +88,13 @@ A fast way to get consul is the following:
     2019/09/24 16:40:14 WARN: version 135 is older or same as the field's AccessToken
     2019/09/24 16:40:15 INFO: field AccessToken updated with value ***, version: 136
     2019/09/24 16:40:16 Config: IndexName: customers-v1, CacheRetention: 86400, LogLevel: DEBUG, AccessToken: newaccesstoken
+
+## 05 Usage of custom config types with complex structure and validation
+
+    2020/01/21 13:39:34 INFO: field IndexName updated with value customers-v1, version: 0
+    2020/01/21 13:39:34 INFO: seed value customers-v1 applied on field IndexName
+    2020/01/21 13:39:34 INFO: field EMail updated with value foo@example.com, version: 0
+    2020/01/21 13:39:34 INFO: seed value foo@example.com applied on field EMail
+    2020/01/21 13:39:34 INFO: field EMail updated with value bar@example.com, version: 0
+    2020/01/21 13:39:34 INFO: env var value bar@example.com applied on field EMail
+    2020/01/21 13:39:34 Config : IndexName: customers-v1, EMail: bar@example.com, EMail.Name: bar, EMail.Domain: example.com

--- a/examples/README.md
+++ b/examples/README.md
@@ -89,7 +89,9 @@ A fast way to get consul is the following:
     2019/09/24 16:40:15 INFO: field AccessToken updated with value ***, version: 136
     2019/09/24 16:40:16 Config: IndexName: customers-v1, CacheRetention: 86400, LogLevel: DEBUG, AccessToken: newaccesstoken
 
-## 05 Usage of custom config types with complex structure and validation
+## 05 Custom config types with complex structure and validation
+
+    go run examples/05_custom_types/main.go
 
     2020/01/21 13:39:34 INFO: field IndexName updated with value customers-v1, version: 0
     2020/01/21 13:39:34 INFO: seed value customers-v1 applied on field IndexName

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -2,6 +2,7 @@ package sync
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 )
 
@@ -35,6 +36,15 @@ func (b *Bool) String() string {
 	return "false"
 }
 
+func (b *Bool) SetString(val string) error {
+	v, err := strconv.ParseBool(val)
+	if err != nil {
+		return err
+	}
+	b.Set(v)
+	return nil
+}
+
 // Int64 type with concurrent access support.
 type Int64 struct {
 	rw    sync.RWMutex
@@ -60,6 +70,15 @@ func (i *Int64) String() string {
 	i.rw.RLock()
 	defer i.rw.RUnlock()
 	return fmt.Sprintf("%d", i.value)
+}
+
+func (i *Int64) SetString(val string) error {
+	v, err := strconv.ParseInt(val, 10, 64)
+	if err != nil {
+		return err
+	}
+	i.Set(v)
+	return nil
 }
 
 // Float64 type with concurrent access support.
@@ -89,6 +108,15 @@ func (f *Float64) String() string {
 	return fmt.Sprintf("%f", f.value)
 }
 
+func (f *Float64) SetString(val string) error {
+	v, err := strconv.ParseFloat(val, 64)
+	if err != nil {
+		return err
+	}
+	f.Set(v)
+	return nil
+}
+
 // String type with concurrent access support.
 type String struct {
 	rw    sync.RWMutex
@@ -116,6 +144,11 @@ func (s *String) String() string {
 	return s.value
 }
 
+func (s *String) SetString(val string) error {
+	s.Set(val)
+	return nil
+}
+
 // Secret string type for secrets with concurrent access support.
 type Secret struct {
 	rw    sync.RWMutex
@@ -139,4 +172,9 @@ func (s *Secret) Set(value string) {
 // String returns obfuscated string representation of value.
 func (s *Secret) String() string {
 	return "***"
+}
+
+func (s *Secret) SetString(val string) error {
+	s.Set(val)
+	return nil
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -36,6 +36,7 @@ func (b *Bool) String() string {
 	return "false"
 }
 
+// SetString parses and sets a value from string type.
 func (b *Bool) SetString(val string) error {
 	v, err := strconv.ParseBool(val)
 	if err != nil {
@@ -72,6 +73,7 @@ func (i *Int64) String() string {
 	return fmt.Sprintf("%d", i.value)
 }
 
+// SetString parses and sets a value from string type.
 func (i *Int64) SetString(val string) error {
 	v, err := strconv.ParseInt(val, 10, 64)
 	if err != nil {
@@ -108,6 +110,7 @@ func (f *Float64) String() string {
 	return fmt.Sprintf("%f", f.value)
 }
 
+// SetString parses and sets a value from string type.
 func (f *Float64) SetString(val string) error {
 	v, err := strconv.ParseFloat(val, 64)
 	if err != nil {
@@ -144,6 +147,7 @@ func (s *String) String() string {
 	return s.value
 }
 
+// SetString parses and sets a value from string type.
 func (s *String) SetString(val string) error {
 	s.Set(val)
 	return nil
@@ -174,6 +178,7 @@ func (s *Secret) String() string {
 	return "***"
 }
 
+// SetString parses and sets a value from string type.
 func (s *Secret) SetString(val string) error {
 	s.Set(val)
 	return nil

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -18,6 +18,13 @@ func TestBool(t *testing.T) {
 	assert.Equal(t, "true", b.String())
 }
 
+func TestBool_SetString(t *testing.T) {
+	var b Bool
+	assert.Error(t, b.SetString("wrong"))
+	assert.NoError(t, b.SetString("true"))
+	assert.True(t, b.Get())
+}
+
 func TestInt64(t *testing.T) {
 	var i Int64
 	ch := make(chan struct{})
@@ -28,6 +35,13 @@ func TestInt64(t *testing.T) {
 	<-ch
 	assert.Equal(t, int64(10), i.Get())
 	assert.Equal(t, "10", i.String())
+}
+
+func TestInt64_SetString(t *testing.T) {
+	var i Int64
+	assert.Error(t, i.SetString("wrong"))
+	assert.NoError(t, i.SetString("10"))
+	assert.Equal(t, int64(10), i.Get())
 }
 
 func TestFloat64(t *testing.T) {
@@ -42,6 +56,13 @@ func TestFloat64(t *testing.T) {
 	assert.Equal(t, "1.230000", f.String())
 }
 
+func TestFloat64_SetString(t *testing.T) {
+	var f Float64
+	assert.Error(t, f.SetString("wrong"))
+	assert.NoError(t, f.SetString("1.230000"))
+	assert.Equal(t, 1.23, f.Get())
+}
+
 func TestString(t *testing.T) {
 	var s String
 	ch := make(chan struct{})
@@ -54,6 +75,12 @@ func TestString(t *testing.T) {
 	assert.Equal(t, "Hello", s.String())
 }
 
+func TestString_SetString(t *testing.T) {
+	var s String
+	assert.NoError(t, s.SetString("foo"))
+	assert.Equal(t, "foo", s.Get())
+}
+
 func TestSecret(t *testing.T) {
 	var s Secret
 	ch := make(chan struct{})
@@ -64,4 +91,10 @@ func TestSecret(t *testing.T) {
 	<-ch
 	assert.Equal(t, "Hello", s.Get())
 	assert.Equal(t, "***", s.String())
+}
+
+func TestSecret_SetString(t *testing.T) {
+	var s Secret
+	assert.NoError(t, s.SetString("foo"))
+	assert.Equal(t, "foo", s.Get())
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Resolves #38 and provides an ability to create custom config field types, not limiting to only `sync` package

## Short description of the changes

It replaces reflection based calls with newly introduced interface (`CfgType`)

With this approach, any client can create custom config types with just three requirements:

1. Custom type must be thread safe
2. Custom type must must implement `CfgType`
3. Custom type must be a struct type

