### PR TITLE
Mask values of properties that are marked as secret

### DIFF
--- a/examples/01_basic/main.go
+++ b/examples/01_basic/main.go
@@ -13,6 +13,7 @@ type config struct {
 	IndexName      sync.String `seed:"customers-v1"`
 	CacheRetention sync.Int64  `seed:"43200" env:"ENV_CACHE_RETENTION_SECONDS"`
 	LogLevel       sync.String `seed:"DEBUG" flag:"loglevel"`
+	DbPassword     sync.String `seed:"mylocalpassword" env:"ENV_DB_PASSWORD" secret:"true"`
 }
 
 func main() {
@@ -20,6 +21,10 @@ func main() {
 	defer cnl()
 
 	err := os.Setenv("ENV_CACHE_RETENTION_SECONDS", "86400")
+	if err != nil {
+		log.Fatalf("failed to set env var: %v", err)
+	}
+	err = os.Setenv("ENV_DB_PASSWORD", "dfs89sSFD*89SDFV7VSD6^SDVvvss")
 	if err != nil {
 		log.Fatalf("failed to set env var: %v", err)
 	}

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -64,7 +64,7 @@ func (s *Seeder) Seed(cfg *config.Config) error {
 			if err != nil {
 				return err
 			}
-			log.Infof("seed value %v applied on field %s", f, f.Name())
+			log.Infof("seed value %v applied on field %s", f.LogValue(), f.Name())
 			seedMap[f] = true
 		}
 		key, ok := ss[config.SourceEnv]
@@ -75,7 +75,7 @@ func (s *Seeder) Seed(cfg *config.Config) error {
 				if err != nil {
 					return err
 				}
-				log.Infof("env var value %v applied on field %s", f, f.Name())
+				log.Infof("env var value %v applied on field %s", f.LogValue(), f.Name())
 				seedMap[f] = true
 			} else {
 				log.Warnf("env var %s did not exist for field %s", key, f.Name())

--- a/seed/seed_test.go
+++ b/seed/seed_test.go
@@ -195,17 +195,19 @@ func TestSeeder_Seed(t *testing.T) {
 				assert.Equal(t, int64(25), c.Age.Get())
 				assert.Equal(t, 99.9, c.Balance.Get())
 				assert.True(t, c.HasJob.Get())
+				assert.Equal(t, "localP@ssword!", c.Password.Get())
 			}
 		})
 	}
 }
 
 type testConfig struct {
-	Name    sync.String  `seed:"John Doe"`
-	Age     sync.Int64   `seed:"18" env:"ENV_AGE"`
-	City    sync.String  `seed:"London" flag:"city"`
-	Balance sync.Float64 `seed:"99.9" env:"ENV_BALANCE"`
-	HasJob  sync.Bool    `seed:"true" env:"ENV_HAS_JOB" consul:"/config/has-job"`
+	Name     sync.String  `seed:"John Doe"`
+	Age      sync.Int64   `seed:"18" env:"ENV_AGE"`
+	City     sync.String  `seed:"London" flag:"city"`
+	Balance  sync.Float64 `seed:"99.9" env:"ENV_BALANCE"`
+	HasJob   sync.Bool    `seed:"true" env:"ENV_HAS_JOB" consul:"/config/has-job"`
+	Password sync.String  `seed:"localP@ssword!" env:"ENV_PASSWORD" secret:"true"`
 }
 
 type testInvalidInt struct {


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/harvester/blob/master/CONTRIBUTE.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/harvester/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

This allows you to mask values that are marked as secret. 
See [this issue](https://github.com/beatlabs/harvester/issues/47)


## Short description of the changes

This change allows you to mark a config value as secret, which will mask the value with `*` with the exception of the first 3 characters which allows for some debugging.

```go
type config struct {
	Password  sync.String `seed:"mypass" env:"ENV_PASSWORD" secret:"true"`
}
```