### PR TITLE
Removed timeout from watcher

### DIFF
--- a/examples/03_consul_monitor/main.go
+++ b/examples/03_consul_monitor/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	h, err := harvester.New(&cfg).
 		WithConsulSeed("127.0.0.1:8500", "", "", 0).
-		WithConsulMonitor("127.0.0.1:8500", "", "", 0, ii...).
+		WithConsulMonitor("127.0.0.1:8500", "", "", ii...).
 		Create()
 	if err != nil {
 		log.Fatalf("failed to create harvester: %v", err)

--- a/examples/04_secrets/main.go
+++ b/examples/04_secrets/main.go
@@ -38,7 +38,7 @@ func main() {
 
 	h, err := harvester.New(&cfg).
 		WithConsulSeed("127.0.0.1:8500", "", "", 0).
-		WithConsulMonitor("127.0.0.1:8500", "", "", 0, ii...).
+		WithConsulMonitor("127.0.0.1:8500", "", "", ii...).
 		Create()
 	if err != nil {
 		log.Fatalf("failed to create harvester: %v", err)

--- a/harvester.go
+++ b/harvester.go
@@ -85,11 +85,11 @@ func (b *Builder) WithConsulSeed(addr, dataCenter, token string, timeout time.Du
 }
 
 // WithConsulMonitor enables support for monitoring key/prefixes on consul.
-func (b *Builder) WithConsulMonitor(addr, dc, token string, timeout time.Duration, ii ...consul.Item) *Builder {
+func (b *Builder) WithConsulMonitor(addr, dc, token string, ii ...consul.Item) *Builder {
 	if b.err != nil {
 		return b
 	}
-	wtc, err := consul.New(addr, dc, token, timeout, ii...)
+	wtc, err := consul.New(addr, dc, token, ii...)
 	if err != nil {
 		b.err = err
 		return b

--- a/harvester_integration_test.go
+++ b/harvester_integration_test.go
@@ -80,7 +80,7 @@ func Test_harvester_Harvest(t *testing.T) {
 	ii := []consul.Item{consul.NewKeyItem("harvester1/name"), consul.NewPrefixItem("harvester")}
 	h, err := New(&cfg).
 		WithConsulSeed(addr, "", "", 0).
-		WithConsulMonitor(addr, "", "", 0, ii...).
+		WithConsulMonitor(addr, "", "", ii...).
 		Create()
 	require.NoError(t, err)
 

--- a/harvester_test.go
+++ b/harvester_test.go
@@ -34,7 +34,7 @@ func TestCreateWithConsul(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got, err := New(tt.args.cfg).
 				WithConsulSeed(tt.args.addr, "", "", 0).
-				WithConsulMonitor(tt.args.addr, "", "", 0, tt.args.items...).
+				WithConsulMonitor(tt.args.addr, "", "", tt.args.items...).
 				Create()
 			if tt.wantErr {
 				assert.Error(t, err)

--- a/monitor/consul/watcher.go
+++ b/monitor/consul/watcher.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/beatlabs/harvester/change"
 	"github.com/beatlabs/harvester/config"
@@ -39,15 +38,12 @@ type Watcher struct {
 }
 
 // New creates a new watcher.
-func New(addr, dc, token string, timeout time.Duration, ii ...Item) (*Watcher, error) {
+func New(addr, dc, token string, ii ...Item) (*Watcher, error) {
 	if addr == "" {
 		return nil, errors.New("address is empty")
 	}
 	if len(ii) == 0 {
 		return nil, errors.New("items are empty")
-	}
-	if timeout == 0 {
-		timeout = 60 * time.Second
 	}
 	cfg := api.DefaultConfig()
 	cfg.Address = addr
@@ -56,7 +52,6 @@ func New(addr, dc, token string, timeout time.Duration, ii ...Item) (*Watcher, e
 	if err != nil {
 		return nil, err
 	}
-	cfg.HttpClient.Timeout = timeout
 
 	cl, err := api.NewClient(cfg)
 	if err != nil {

--- a/monitor/consul/watcher_integration_test.go
+++ b/monitor/consul/watcher_integration_test.go
@@ -43,7 +43,7 @@ func TestMain(m *testing.M) {
 
 func TestWatch(t *testing.T) {
 	ch := make(chan []*change.Change)
-	w, err := New(addr, "", "", 0, NewKeyItem("key1"), NewPrefixItem("prefix1"))
+	w, err := New(addr, "", "", NewKeyItem("key1"), NewPrefixItem("prefix1"))
 	require.NoError(t, err)
 	require.NotNil(t, w)
 	ctx, cnl := context.WithCancel(context.Background())

--- a/monitor/consul/watcher_test.go
+++ b/monitor/consul/watcher_test.go
@@ -3,7 +3,6 @@ package consul
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/beatlabs/harvester/change"
 	"github.com/stretchr/testify/assert"
@@ -13,23 +12,21 @@ import (
 func TestNew(t *testing.T) {
 	ii := []Item{{}}
 	type args struct {
-		addr    string
-		timeout time.Duration
-		ii      []Item
+		addr string
+		ii   []Item
 	}
 	tests := []struct {
 		name    string
 		args    args
 		wantErr bool
 	}{
-		{name: "success", args: args{addr: "xxx", timeout: 1 * time.Second, ii: ii}, wantErr: false},
-		{name: "success default timeout", args: args{addr: "xxx", timeout: 0, ii: ii}, wantErr: false},
-		{name: "empty address", args: args{addr: "", timeout: 1 * time.Second, ii: ii}, wantErr: true},
-		{name: "empty items", args: args{addr: "xxx", timeout: 1 * time.Second, ii: nil}, wantErr: true},
+		{name: "success", args: args{addr: "xxx", ii: ii}, wantErr: false},
+		{name: "empty address", args: args{addr: "", ii: ii}, wantErr: true},
+		{name: "empty items", args: args{addr: "xxx", ii: nil}, wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(tt.args.addr, "dc", "token", tt.args.timeout, tt.args.ii...)
+			got, err := New(tt.args.addr, "dc", "token", tt.args.ii...)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Nil(t, got)
@@ -42,7 +39,7 @@ func TestNew(t *testing.T) {
 }
 
 func TestWatcher_Watch(t *testing.T) {
-	w, err := New("xxx", "", "", 0, Item{})
+	w, err := New("xxx", "", "", Item{})
 	require.NoError(t, err)
 	type args struct {
 		ctx context.Context


### PR DESCRIPTION
By providing a timeout, Harvester will interrupt the Consul long poll request which results in a net/http request cancelled exception that get's logged as an error in Consul

<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/harvester/blob/master/CONTRIBUTE.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/harvester/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

By providing a timeout to the HttpClient in the watcher, the client will kill the long poll request to Consul (which is waiting for changes). This results in the following error every time the timeout expires for each key that Harvester is subscribed to:

```
[ERR] consul.watch: Watch (type: key) errored: Get http://consul-address:8500/v1/kv/group/key?index=42: net/http: request canceled (Client.Timeout exceeded while awaiting headers), retry in 5s
```

## Short description of the changes

By removing the timeout argument and removing the default timeout, long polling will work correctly.
