### PR TITLE
Changed use of timeout, instead of setting it on the httpclient, set it in the consul client

### DIFF
--- a/monitor/consul/watcher.go
+++ b/monitor/consul/watcher.go
@@ -48,11 +48,6 @@ func New(addr, dc, token string, timeout time.Duration, ii ...Item) (*Watcher, e
 	}
 	cfg := api.DefaultConfig()
 	cfg.Address = addr
-	var err error
-	cfg.HttpClient, err = api.NewHttpClient(cfg.Transport, cfg.TLSConfig)
-	if err != nil {
-		return nil, err
-	}
 	if timeout > 0 {
 		cfg.WaitTime = timeout
 	}

--- a/monitor/consul/watcher.go
+++ b/monitor/consul/watcher.go
@@ -46,9 +46,6 @@ func New(addr, dc, token string, timeout time.Duration, ii ...Item) (*Watcher, e
 	if len(ii) == 0 {
 		return nil, errors.New("items are empty")
 	}
-	if timeout == 0 {
-		timeout = 60 * time.Second
-	}
 	cfg := api.DefaultConfig()
 	cfg.Address = addr
 	var err error
@@ -56,7 +53,9 @@ func New(addr, dc, token string, timeout time.Duration, ii ...Item) (*Watcher, e
 	if err != nil {
 		return nil, err
 	}
-	cfg.HttpClient.Timeout = timeout
+	if timeout > 0 {
+		cfg.WaitTime = timeout
+	}
 
 	cl, err := api.NewClient(cfg)
 	if err != nil {


### PR DESCRIPTION
Followup from PR https://github.com/beatlabs/harvester/pull/55

<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/harvester/blob/master/CONTRIBUTE.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/harvester/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

By providing a timeout to the HttpClient in the watcher, the client will kill the long poll request to Consul (which is waiting for changes). This results in the following error every time the timeout expires for each key that Harvester is subscribed to:

```
[ERR] consul.watch: Watch (type: key) errored: Get http://consul-address:8500/v1/kv/group/key?index=42: net/http: request canceled (Client.Timeout exceeded while awaiting headers), retry in 5s
```

## Short description of the changes

By removing the timeout in the http client and setting it on the consul client, long polling works correctly.
