### PR TITLE
Use harvester's logger with hclog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# Intellij idea workspace
+.idea

--- a/log/log.go
+++ b/log/log.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io"
 	"log"
-	"os"
 )
 
 // Func function definition.
@@ -23,7 +22,6 @@ var (
 	errorf = func(format string, v ...interface{}) {
 		log.Printf("ERROR: "+format, v...)
 	}
-	writer io.Writer = os.Stdout
 )
 
 // Setup allows for setting up custom loggers.
@@ -47,13 +45,12 @@ func Setup(wr io.Writer, inf, waf, erf, dbf Func) error {
 	warnf = waf
 	errorf = erf
 	debugf = dbf
-	writer = wr
 	return nil
 }
 
 // Writer returns the loggers writer interface.
 func Writer() io.Writer {
-	return writer
+	return writer{}
 }
 
 // Infof provides log info capabilities.
@@ -74,4 +71,14 @@ func Errorf(format string, v ...interface{}) {
 // Debugf provides log debug capabilities.
 func Debugf(format string, v ...interface{}) {
 	debugf(format, v...)
+}
+
+// writer is a wrapper around harvester's logger that implements io.Writer.
+// It is available so we can keep using harvester's logger for external dependencies that require io.Writer (like hclog).
+type writer struct{}
+
+// Write log using log.Errorf() and will never returns an error.
+func (writer) Write(p []byte) (n int, err error) {
+	Errorf(string(p))
+	return len(p), nil
 }

--- a/monitor/consul/watcher.go
+++ b/monitor/consul/watcher.go
@@ -59,6 +59,8 @@ func New(addr, dc, token string, timeout time.Duration, ii ...Item) (*Watcher, e
 	return &Watcher{cl: cl, dc: dc, token: token, ii: ii}, nil
 }
 
+
+
 // Watch key and prefixes for changes.
 func (w *Watcher) Watch(ctx context.Context, ch chan<- []*change.Change) error {
 	if ctx == nil {


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/harvester/blob/master/CONTRIBUTE.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/harvester/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?
https://github.com/beatlabs/harvester/issues/61

## Short description of the changes
Add a small struct implementing io.Writer which calls Errorf, this way even if an external dependency requires io.Writer for loggin (like hclog) it willstill go thorugh the logger that was set up in log.Setup

**Important note**: this is a breaking change as the signature of log.Setup changes, we can also leave the signature as it used to be and just ignore the value of the writer parameter.