### PR TITLE
Add early return to Redis watcher in case of MGET error to avoid panicking

### DIFF
--- a/monitor/redis/watcher.go
+++ b/monitor/redis/watcher.go
@@ -68,6 +68,7 @@ func (w *Watcher) getValues(ctx context.Context, ch chan<- []*change.Change) {
 	values, err := w.client.MGet(ctx, w.keys...).Result()
 	if err != nil {
 		log.Errorf("failed to MGET keys %v: %v", w.keys, err)
+		return
 	}
 	changes := make([]*change.Change, 0, len(w.keys))
 


### PR DESCRIPTION
<!--
Thanks for taking precious time for making a PR.

Before creating a pull request, please make sure:
- Your PR solves one problem for which a issue exist and a solution has been discussed
- You have read the guide for contributing
  - See https://github.com/beatlabs/harvester/blob/master/CONTRIBUTE.md
- You signed all your commits (otherwise we won't be able to merge the PR)
  - See https://github.com/beatlabs/harvester/blob/master/SIGNYOURWORK.md
- You added unit tests for the new functionality
- You mention in the PR description which issue it is addressing, e.g. "Resolves #123"
-->

## Which problem is this PR solving?

In case of MGET error current implementation still expects resulting values array to have the same length as keys array, tries to iterave over them and panicks with:
```
runtime error: index out of range [0]
github.com/beatlabs/harvester/monitor/redis.(*Watcher).
      getValues(0xc00011dad0, 0x1516268, 0xc000042050, 
      /go/sonar/vendor/github.com/beatlabs/harvester/monitor/redis/watcher.go:75
github.com/beatlabs/harvester/monitor/redis.(*Watcher).
      monitor(0xc00011dad0, 0x1516268, 0xc000042050, 0xc0001311a0) 
      /go/sonar/vendor/github.com/beatlabs/harvester/monitor/redis/watcher.go:62
```

## Short description of the changes

Add an early return in case of error.
