### PR TITLE
Add StringMap type

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The fields have to be one of the types that the sync package supports in order t
 - sync.Bool, allows for concurrent bool manipulation
 - sync.Secret, allows for concurrent secret manipulation. Secrets can only be strings
 - sync.TimeDuration, allows for concurrent time.duration manipulation.
+- sync.StringMap, allows for concurrent map[string]string manipulation.
 
 For sensitive configuration (passwords, tokens, etc.) that shouldn't be printed in log, you can use the `Secret` flavor of `sync` types. If one of these is selected, then at harvester log instead of the real value the text `***` will be displayed.
 

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -225,23 +225,27 @@ func (s *Secret) SetString(val string) error {
 	return nil
 }
 
+// StringMap is a map[string]string type with concurrent access support.
 type StringMap struct {
 	rw    sync.RWMutex
 	value map[string]string
 }
 
+// Get returns the internal value.
 func (s *StringMap) Get() map[string]string {
 	s.rw.RLock()
 	defer s.rw.RUnlock()
 	return s.value
 }
 
+// Set a value.
 func (s *StringMap) Set(value map[string]string) {
 	s.rw.Lock()
 	defer s.rw.Unlock()
 	s.value = value
 }
 
+// String returns a string representation of the value.
 func (s *StringMap) String() string {
 	s.rw.RLock()
 	defer s.rw.RUnlock()
@@ -254,8 +258,9 @@ func (s *StringMap) String() string {
 	return b.String()
 }
 
+// SetString parses and sets a value from string type.
 func (s *StringMap) SetString(val string) error {
-	dict := make(map[string]string, 0)
+	dict := make(map[string]string)
 	if val == "" || strings.TrimSpace(val) == "" {
 		s.Set(dict)
 		return nil

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -2,8 +2,10 @@
 package sync
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -220,5 +222,52 @@ func (s *Secret) String() string {
 // SetString parses and sets a value from string type.
 func (s *Secret) SetString(val string) error {
 	s.Set(val)
+	return nil
+}
+
+type StringMap struct {
+	rw    sync.RWMutex
+	value map[string]string
+}
+
+func (s *StringMap) Get() map[string]string {
+	s.rw.RLock()
+	defer s.rw.RUnlock()
+	return s.value
+}
+
+func (s *StringMap) Set(value map[string]string) {
+	s.rw.Lock()
+	defer s.rw.Unlock()
+	s.value = value
+}
+
+func (s *StringMap) String() string {
+	s.rw.RLock()
+	defer s.rw.RUnlock()
+	b := new(bytes.Buffer)
+	firstChar := ""
+	for key, value := range s.value {
+		_, _ = fmt.Fprintf(b, "%s%s=%q", firstChar, key, value)
+		firstChar = ","
+	}
+	return b.String()
+}
+
+func (s *StringMap) SetString(val string) error {
+	dict := make(map[string]string, 0)
+	if val == "" || strings.TrimSpace(val) == "" {
+		s.Set(dict)
+		return nil
+	}
+	for _, pair := range strings.Split(val, ",") {
+		items := strings.SplitN(pair, ":", 2)
+		if len(items) != 2 {
+			return fmt.Errorf("map must be formatted as `key:value`, got %q", pair)
+		}
+		key, value := strings.TrimSpace(items[0]), strings.TrimSpace(items[1])
+		dict[key] = value
+	}
+	s.Set(dict)
 	return nil
 }


### PR DESCRIPTION
## Which problem is this PR solving?

We find ourselves creating map like datatypes to most projects where we use Harvester, I think a build in one would be nice.

## Short description of the changes

Added the `sync.StringMap` type, expects key/value pairs separated by `,`, and keys and values separated by `:`.