### PR TITLE
Fix NPE bugs in sync.Regexp

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -330,9 +330,7 @@ func (r *Regexp) Set(value *regexp.Regexp) {
 
 // MarshalJSON returns the JSON encoding of the value.
 func (r *Regexp) MarshalJSON() ([]byte, error) {
-	r.rw.RLock()
-	defer r.rw.RUnlock()
-	return json.Marshal(r.value.String())
+	return json.Marshal(r.String())
 }
 
 // UnmarshalJSON returns the JSON encoding of the value.
@@ -354,9 +352,11 @@ func (r *Regexp) UnmarshalJSON(d []byte) error {
 
 // String returns a string representation of the value.
 func (r *Regexp) String() string {
-	r.rw.RLock()
-	defer r.rw.RUnlock()
-	return r.value.String()
+	regex := r.Get()
+	if regex == nil {
+		return ""
+	}
+	return regex.String()
 }
 
 //

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -267,6 +267,18 @@ func TestRegexp_SetString(t *testing.T) {
 	}
 }
 
+func TestRegexp_String(t *testing.T) {
+	sr := Regexp{}
+	assert.Equal(t, "", sr.String())
+}
+
+func TestRegexp_MarshalJSON(t *testing.T) {
+	sr := Regexp{}
+	json, err := sr.MarshalJSON()
+	assert.Equal(t, []byte(`""`), json)
+	assert.NoError(t, err)
+}
+
 func TestStringMap(t *testing.T) {
 	var sm StringMap
 	ch := make(chan struct{})


### PR DESCRIPTION
## Which problem is this PR solving?

There's a few nil pointer bugs in the new sync.Regexp

Followup from https://github.com/beatlabs/harvester/pull/142
