### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,9 @@ on:
       - master
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint and fmt check


### PR DESCRIPTION
Potential fix for [https://github.com/beatlabs/harvester/security/code-scanning/2](https://github.com/beatlabs/harvester/security/code-scanning/2)

The optimal fix is to explicitly specify the minimum required permissions for the workflow or specific jobs. In this workflow, both jobs use code checkout (so `contents: read` is required), and the Codecov upload step may require uploading artifacts but typically also works with `contents: read`. Unless a job step specifically needs more (like `pull-requests: write`, etc.), starting with just `contents: read` is safest.

This can be set at the workflow root, above the `jobs:` block, so all jobs inherit this minimal permission. Edit `.github/workflows/go.yml` by inserting:

```yaml
permissions:
  contents: read
```
after the `name:` block and before `on:` (or after `on:`, before `jobs:`, as GitHub allows). This ensures child jobs don't get needless token permissions.

No new methods, imports, or complex definitions are needed — just a small edit to the YAML.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Security
  * Restricted CI workflow token to read-only repository access, reducing attack surface and preventing unintended modifications.
* Chores
  * Updated CI configuration to enforce minimal permissions; no changes to workflow triggers, jobs, or execution behavior.
  * No impact on user-facing features or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->