### PR TITLE
Phase 3: Release notes, security scanning & stale issue cleanup

### DIFF
--- a/.github/workflows/release-notes-generator.md
+++ b/.github/workflows/release-notes-generator.md
@@ -1,0 +1,63 @@
+---
+description: Generate tag-based GitHub Release notes for harvester.
+on:
+  push:
+    tags:
+      - "v*"
+tools:
+  - github[repos, pull_requests, issues]
+  - bash
+imports:
+  - shared/mood.md
+  - shared/release-notes-template.md
+engine: copilot
+strict: true
+timeout-minutes: 15
+permissions:
+  contents: read
+  pull-requests: read
+  issues: read
+safe-outputs:
+  update-release:
+    max: 1
+  add-comment:
+    max: 1
+---
+
+# Release Notes Generator
+
+Generate release notes for the pushed tag and update the matching GitHub Release body.
+
+## Requirements
+
+1. Detect the pushed tag from the workflow context.
+2. Find the previous tag. If there is no previous tag, treat this as the first release.
+3. Collect all commits between the previous tag and the pushed tag. If this is the first release, use all commits reachable by the pushed tag.
+4. Map commits to merged pull requests where possible using commit metadata, associated PRs, and issue references.
+5. Categorize changes using pull request labels first, then commit messages when labels are unavailable:
+   - `breaking-change`, `api-change` → `Breaking Changes`
+   - `feature` → `New Features`
+   - `enhancement` → `Improvements`
+   - `bug` → `Bug Fixes`
+   - `dependencies`, `dependabot` → `Dependencies`
+6. Build the release body from the shared `release-notes-template.md` import.
+7. Keep the `Breaking Changes` section at the top and include migration guidance for every breaking change.
+8. In the `Dependencies` section, summarize `go.mod` and `go.sum` changes when present.
+9. In the `Contributors` section, list first-time contributors by checking whether each commit author has prior commits in the repository before this release range.
+10. Handle edge cases:
+    - no previous tag
+    - no merged PRs for some or all commits
+    - commit-only releases where PR mapping is unavailable
+
+## Execution Notes
+
+- Use `bash` for tag diffing, commit range calculation, and assembling the final release body.
+- Use GitHub repository, pull request, and issue data to enrich entries with PR numbers, links, labels, and short descriptions.
+- For commit-only entries with no PR mapping, still include them in the most appropriate section using the commit message and commit link.
+- Keep entries concise and link to the PR when available.
+- Do not assume any release tooling beyond tags and GitHub Releases.
+
+## Outputs
+
+- Use `update-release` once to populate the GitHub Release body for the pushed tag.
+- If the GitHub Release does not exist yet, use `add-comment` once to note that the release was not found and could not be updated.

--- a/.github/workflows/security-scanner.md
+++ b/.github/workflows/security-scanner.md
@@ -1,0 +1,72 @@
+---
+on:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+  push:
+    branches: [master]
+    paths: ["go.mod", "go.sum"]
+permissions:
+  contents: read
+  issues: read
+tools:
+  github: [issues, repos, dependabot]
+  bash: true
+safe-outputs:
+  create-issue:
+    title-prefix: "[security]"
+    labels: ["security", "P1-high"]
+    max: 3
+    close-older-issues: true
+    skip-if-match: "\\[security\\].*CVE-.*open"
+  add-labels:
+    max: 2
+imports:
+  - shared/mood.md
+  - shared/go-security.md
+engine: copilot
+strict: true
+timeout-minutes: 20
+network:
+  allowed: [defaults, vuln.go.dev]
+---
+
+# Security Scanner
+
+Run a focused Go security scan for this repository.
+
+## Objectives
+
+- Run `govulncheck ./...` to detect known vulnerabilities in dependencies.
+- Run `gosec ./...` for static security analysis of Go code.
+- Audit `go.mod` and `go.sum` for dependency health signals.
+
+## Severity classification
+
+- **Critical**: Known exploitable CVE in a direct dependency.
+- **High**: CVE in a direct dependency that is not yet exploitable in this codebase.
+- **Medium**: CVE in a transitive dependency.
+- **Low / Informational**: `gosec` style findings and best-practice warnings.
+
+## Issue creation rules
+
+- Create issues only for **Critical** and **High** findings.
+- Deduplicate by CVE; do not create duplicate issues for the same vulnerability.
+- Include the **CVE ID in the issue title** for deduplication via `skip-if-match`.
+- Create at most **3 issues per run**, prioritized by severity.
+- Add the `security` label to all findings.
+- Add the `dependency` label when the finding is dependency-related.
+- Clearly separate actionable findings from informational ones in the issue body.
+
+## Required issue content
+
+For each created issue, include:
+
+- CVE ID in the title.
+- Affected dependency and version.
+- Whether the dependency is direct or transitive.
+- Recommended remediation: upgrade, replace, or mitigate.
+
+## Repository context
+
+If the repository already has `gosec` coverage through its lint configuration (as patron does), treat this workflow as complementary rather than duplicative.

--- a/.github/workflows/stale-issue-cleanup.md
+++ b/.github/workflows/stale-issue-cleanup.md
@@ -1,0 +1,63 @@
+---
+on:
+  schedule:
+    - cron: "0 5 * * 0"
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: read
+safe-outputs:
+  add-comment:
+    title-prefix: "[stale]"
+    max: 10
+  add-labels:
+    max: 10
+  close-issue:
+    max: 5
+tools:
+  - github[issues, labels]
+  - bash
+imports:
+  - shared/mood.md
+  - shared/issue-triage-go.md
+engine: copilot
+strict: true
+timeout-minutes: 15
+---
+
+You are performing stale issue cleanup for this repository.
+
+Goals:
+- Scan open issues for staleness signals.
+- Process warnings first, then closures.
+- Limit actions to a maximum of 10 warnings and 5 closures per run.
+- Be transparent: every action must include a comment explaining why.
+
+Use GitHub issues and labels tools for issue inspection, comments, labels, and closures. Use bash only for date arithmetic and inactivity window calculations.
+
+Staleness rules:
+- No activity for 60+ days (including comments, label changes, and assignee changes) -> warning candidate.
+- No activity for 90+ days after warning -> close candidate.
+
+Warning phase:
+- Add the `stale` label.
+- Post a `[stale]` comment explaining that the issue has been inactive and will be closed in 30 days if there is still no activity.
+- Invite the author or maintainers to respond if the issue is still relevant.
+
+Close phase:
+- Only close issues that were warned 30+ days ago and still have no activity.
+- Post a `[stale]` closing comment explaining why the issue is being closed.
+- Close no more than 5 issues in a single run.
+
+Never close issues with any of the following:
+- `P1-high`
+- `security`
+- `keep-open`
+- Active assignees who have committed recently.
+- Recent linked PR activity in the last 30 days.
+
+Additional requirements:
+- Do not surprise users with closures; warning must happen before closure.
+- Warnings and closures must both include clear explanatory comments.
+- Prioritize safety over throughput.
+- If an issue has recent activity or any exemption applies, leave it open.


### PR DESCRIPTION
## Summary

Phase 3 of the gh-aw rollout — release automation, security, and housekeeping workflows for harvester.

### New Workflows
- **`release-notes-generator`** — Tag-triggered (`v*`): generates release notes from commits since last tag using the shared release-notes-template
- **`security-scanner`** — Weekly + on go.mod/go.sum push: runs govulncheck + gosec, creates issues for findings with severity/CVE details
- **`stale-issue-cleanup`** — Weekly (Sun 5am UTC): warns on issues inactive >60 days, closes after 14-day grace period

### QA
- Verify `gh aw compile` succeeds for all 3 workflows
- Verify `release-notes-generator` triggers on tag push (`v*`) and workflow_dispatch
- Verify `security-scanner` triggers on schedule, push (go.mod/go.sum), and workflow_dispatch
- Verify `stale-issue-cleanup` triggers on schedule and workflow_dispatch
- Verify security-scanner imports `shared/go-security.md` from aw-common
- Verify release-notes-generator imports `shared/release-notes-template.md` from aw-common