### PR TITLE
[codex] Improve test coverage

### DIFF
--- a/examples/main_integration_test.go
+++ b/examples/main_integration_test.go
@@ -41,5 +41,5 @@ func TestExampleHelpersIntegration(t *testing.T) {
 }
 
 func TestMainIntegration(t *testing.T) {
-	main()
+	require.NotPanics(t, main)
 }

--- a/examples/main_integration_test.go
+++ b/examples/main_integration_test.go
@@ -1,0 +1,45 @@
+//go:build integration
+// +build integration
+
+package main
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExampleHelpersIntegration(t *testing.T) {
+	t.Cleanup(func() {
+		assert.NoError(t, os.Unsetenv("ENV_CACHE_RETENTION_SECONDS"))
+	})
+
+	setEnvVarCacheRetention()
+	assert.Equal(t, "86400", os.Getenv("ENV_CACHE_RETENTION_SECONDS"))
+
+	seedConsulAccessToken("integration-token")
+	cl, err := api.NewClient(api.DefaultConfig())
+	require.NoError(t, err)
+	pair, _, err := cl.KV().Get("harvester/example/accesstoken", nil)
+	require.NoError(t, err)
+	require.NotNil(t, pair)
+	assert.Equal(t, "integration-token", string(pair.Value))
+
+	err = setRedisOpeningBalance(context.Background(), "1234.56")
+	require.NoError(t, err)
+	client := createRedisClient()
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+	got, err := client.Get(context.Background(), "opening-balance").Result()
+	require.NoError(t, err)
+	assert.Equal(t, "1234.56", got)
+}
+
+func TestMainIntegration(t *testing.T) {
+	main()
+}

--- a/examples/main_test.go
+++ b/examples/main_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmail(t *testing.T) {
+	var email Email
+
+	err := email.SetString("invalid")
+	require.Error(t, err)
+	assert.Empty(t, email.Get())
+
+	err = email.SetString("foo@example.com")
+	require.NoError(t, err)
+	assert.Equal(t, "foo@example.com", email.Get())
+	assert.Equal(t, "foo", email.GetName())
+	assert.Equal(t, "example.com", email.GetDomain())
+	assert.Equal(t, email.Get(), email.String())
+}
+
+func TestConfigString(t *testing.T) {
+	var cfg config
+	require.NoError(t, cfg.IndexName.SetString("customers-v2"))
+	require.NoError(t, cfg.CacheRetention.SetString("86400"))
+	require.NoError(t, cfg.LogLevel.SetString("INFO"))
+	require.NoError(t, cfg.OpeningBalance.SetString("123.45"))
+	require.NoError(t, cfg.AccessToken.SetString("secret"))
+	require.NoError(t, cfg.Email.SetString("bar@example.com"))
+
+	got := cfg.String()
+	assert.Contains(t, got, "IndexName: customers-v2")
+	assert.Contains(t, got, "CacheRetention: 86400")
+	assert.Contains(t, got, "LogLevel: INFO")
+	assert.Contains(t, got, "OpeningBalance: 123.450000")
+	assert.Contains(t, got, "AccessToken: secret")
+	assert.Contains(t, got, "Email: bar@example.com")
+	assert.True(t, strings.HasPrefix(got, "config:"))
+}
+
+func TestCreateRedisClient(t *testing.T) {
+	client := createRedisClient()
+	require.NotNil(t, client)
+	t.Cleanup(func() {
+		assert.NoError(t, client.Close())
+	})
+	assert.NotNil(t, client.Options())
+}

--- a/monitor/consul/log_test.go
+++ b/monitor/consul/log_test.go
@@ -30,6 +30,7 @@ func Test_clog(t *testing.T) {
 		assert.Equal(t, "consul", logger.Name())
 		assert.NotNil(t, logger.Named(""))
 		assert.NotNil(t, logger.ResetNamed(""))
+		logger.SetLevel(hclog.Info)
 		assert.NotNil(t, logger.StandardLogger(nil))
 		assert.Equal(t, os.Stderr, logger.StandardWriter(nil))
 		assert.Equal(t, hclog.NoLevel, logger.GetLevel())

--- a/monitor/consul/watcher_test.go
+++ b/monitor/consul/watcher_test.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/beatlabs/harvester/change"
+	"github.com/beatlabs/harvester/config"
+	"github.com/hashicorp/consul/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -79,4 +81,59 @@ func TestItems(t *testing.T) {
 		item := NewPrefixItem("prefix1")
 		assert.Equal(t, Item{tp: "keyprefix", key: "prefix1"}, item)
 	})
+}
+
+func TestWatcher_createKeyPlanWithPrefix(t *testing.T) {
+	w, err := New("xxx", "dc", "token", 0, NewKeyItem("key"))
+	require.NoError(t, err)
+
+	ch := make(chan []*change.Change, 1)
+	pl, err := w.createKeyPlanWithPrefix("key", "prefix", ch)
+	require.NoError(t, err)
+	require.NotNil(t, pl)
+
+	pl.Handler(0, nil)
+	assert.Empty(t, ch)
+
+	pl.Handler(0, "not a kv pair")
+	assert.Empty(t, ch)
+
+	pl.Handler(0, &api.KVPair{Key: "prefix/key", Value: []byte("value"), ModifyIndex: 42})
+	require.Len(t, ch, 1)
+	changes := <-ch
+	require.Len(t, changes, 1)
+	assert.Equal(t, config.SourceConsul, changes[0].Source())
+	assert.Equal(t, "key", changes[0].Key())
+	assert.Equal(t, "value", changes[0].Value())
+	assert.Equal(t, uint64(42), changes[0].Version())
+}
+
+func TestWatcher_createKeyPrefixPlan(t *testing.T) {
+	w, err := New("xxx", "dc", "token", 0, NewPrefixItem("prefix"))
+	require.NoError(t, err)
+
+	ch := make(chan []*change.Change, 1)
+	pl, err := w.createKeyPrefixPlan("prefix", ch)
+	require.NoError(t, err)
+	require.NotNil(t, pl)
+
+	pl.Handler(0, nil)
+	assert.Empty(t, ch)
+
+	pl.Handler(0, "not kv pairs")
+	assert.Empty(t, ch)
+
+	pl.Handler(0, api.KVPairs{
+		{Key: "prefix/one", Value: []byte("one"), ModifyIndex: 11},
+		{Key: "prefix/two", Value: []byte("two"), ModifyIndex: 12},
+	})
+	require.Len(t, ch, 1)
+	changes := <-ch
+	require.Len(t, changes, 2)
+	assert.Equal(t, "prefix/one", changes[0].Key())
+	assert.Equal(t, "one", changes[0].Value())
+	assert.Equal(t, uint64(11), changes[0].Version())
+	assert.Equal(t, "prefix/two", changes[1].Key())
+	assert.Equal(t, "two", changes[1].Value())
+	assert.Equal(t, uint64(12), changes[1].Version())
 }


### PR DESCRIPTION
## Which problem is this PR solving?

Improves test coverage for existing behavior, especially integration coverage included by `task cover`.

Issue: N/A, coverage-only maintenance change requested directly.

## Short description of the changes

- Added tests for the example package helpers and integration flow.
- Added Consul watcher handler coverage for key and key-prefix plans.
- Covered the Consul hclog adapter `SetLevel` method.

## Validation

- `go test ./monitor/consul -cover`
- `go test ./... -coverpkg=./... -coverprofile=/tmp/harvester-unit-cover-after.out -covermode=atomic`
- `go test ./examples -cover`
- `go test ./examples -cover -tags=integration -count=1`
- `task testint`
- `task cover` reports total coverage `94.0%`

## Notes

GitNexus changed-scope check reported no production symbol impact.
